### PR TITLE
Add 6 new event types

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -98,10 +98,16 @@ impl Semantics {
 					"blur" => quote! { set_onblur },
 					"focus" => quote! { set_onfocus },
 					"click" => quote! { set_onclick },
+					"dblclick" => quote! { set_ondblclick },
 					"mouseover" => quote! { set_onmouseover },
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
+					"input" => quote! { set_oninput },
+					"change" => quote! { set_onchange },
+					"keydown" => quote! { set_onkeydown },
+					"keyup" => quote! { set_onkeyup },
+					"scroll" => quote! { set_onscroll },
 					_ => panic!("unknown event id"),
 				};
 

--- a/tests/misc/new_events.rs
+++ b/tests/misc/new_events.rs
@@ -1,0 +1,92 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn dblclick() {
+	test_setup! {
+		text: "double click me";
+		?dblclick {
+			text: "double clicked";
+		}
+	}
+	assert_eq!(root.inner_html(), "double click me");
+	let event = web_sys::Event::new("dblclick").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "double clicked");
+}
+
+#[wasm_bindgen_test]
+fn input_event() {
+	test_setup! {
+		text: "waiting";
+		?input {
+			text: "got input";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	let event = web_sys::Event::new("input").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "got input");
+}
+
+#[wasm_bindgen_test]
+fn change_event() {
+	test_setup! {
+		text: "unchanged";
+		?change {
+			text: "changed";
+		}
+	}
+	assert_eq!(root.inner_html(), "unchanged");
+	let event = web_sys::Event::new("change").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "changed");
+}
+
+#[wasm_bindgen_test]
+fn keydown_event() {
+	test_setup! {
+		text: "press a key";
+		?keydown {
+			text: "key pressed";
+		}
+	}
+	assert_eq!(root.inner_html(), "press a key");
+	let event = web_sys::Event::new("keydown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "key pressed");
+}
+
+#[wasm_bindgen_test]
+fn keyup_event() {
+	test_setup! {
+		text: "hold a key";
+		?keyup {
+			text: "key released";
+		}
+	}
+	assert_eq!(root.inner_html(), "hold a key");
+	let event = web_sys::Event::new("keyup").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "key released");
+}
+
+#[wasm_bindgen_test]
+fn scroll_event() {
+	test_setup! {
+		text: "scroll me";
+		?scroll {
+			text: "scrolled";
+		}
+	}
+	assert_eq!(root.inner_html(), "scroll me");
+	let event = web_sys::Event::new("scroll").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "scrolled");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod new_events;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds `dblclick`, `input`, `change`, `keydown`, `keyup`, `scroll` event types
- CUI now supports 13 event types total (was 7)
- Each is a single new match arm in the listener compilation

## Changes
- `compiled.rs` — 6 new match arms mapping event names to `set_on*` handlers
- 6 new tests in `tests/misc/new_events.rs`, one per event type

## Test plan
- [x] All 49 wasm-pack tests pass (43 existing + 6 new event tests)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)