### PR TITLE
Implement @if conditional rendering

### DIFF
--- a/src/data/ast.rs
+++ b/src/data/ast.rs
@@ -20,6 +20,7 @@ pub struct Block {
 	pub listeners: Vec<Block>,
 	pub variables: Vec<(String, Value)>,
 	pub assignments: Vec<(String, Value)>,
+	pub conditionals: Vec<(Variable, Block)>,
 }
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]

--- a/src/data/semantics/group.rs
+++ b/src/data/semantics/group.rs
@@ -28,6 +28,10 @@ pub struct Group {
 	pub members: Vec<usize>,
 	pub has_css_properties: bool,
 	pub is_dynamic: bool,
+
+	// for conditional (@if) wrapper elements
+	pub conditional_variable: Option<String>,
+	pub conditional_variable_id: Option<usize>,
 }
 impl Group {
 	pub fn new(
@@ -54,6 +58,9 @@ impl Group {
 			members: Vec::new(),
 			has_css_properties: false,
 			is_dynamic: false,
+
+			conditional_variable: None,
+			conditional_variable_id: None,
 		}
 	}
 
@@ -85,6 +92,9 @@ impl Group {
 			members: Vec::new(),
 			has_css_properties: self.has_css_properties,
 			is_dynamic: false,
+
+			conditional_variable: None,
+			conditional_variable_id: None,
 		}
 	}
 

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -124,6 +124,11 @@ impl Semantics {
 		for block in block.elements {
 			self.create_group_from_block(block, page_id, Some(group_id), listener_scope);
 		}
+		for (variable, conditional_block) in block.conditionals {
+			let wrapper_id = self.groups.len();
+			self.create_group_from_block(conditional_block, page_id, Some(group_id), listener_scope);
+			self.groups[wrapper_id].conditional_variable = Some(variable.0.to_string());
+		}
 	}
 
 	fn create_semantic_value(&self, value: &AstValue) -> Value {

--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -74,11 +74,29 @@ impl Semantics {
 				}
 			});
 
+		let conditional = if let Some(variable_id) = self.groups[element_id].conditional_variable_id {
+			if let (_, Some(mutable_id)) = self.variables[variable_id] {
+				quote! {
+					state[#mutable_id].1.push(
+						Effect {
+							property: Property::Css("display"),
+							target: EffectTarget::Conditional(element.clone()),
+						}
+					);
+				}
+			} else {
+				quote! {}
+			}
+		} else {
+			quote! {}
+		};
+
 		quote! {
 			#( #elements )*
 			#( #classes )*
 			#listeners
 			#( #variables )*
+			#conditional
 		}
 	}
 

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -140,6 +140,10 @@ impl Semantics {
 									render_property(&element, property, state[#mutable_id].0.clone());
 								}
 							}
+							EffectTarget::Conditional(element) => {
+								let display = if is_truthy(&state[#mutable_id].0) { "block" } else { "none" };
+								element.style().set_property("display", display).unwrap();
+							}
 						}
 					}
 				}

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -56,6 +56,15 @@ fn header() -> TokenStream {
 		enum EffectTarget {
 			Element(HtmlElement),
 			Class(&'static str),
+			Conditional(HtmlElement),
+		}
+
+		fn is_truthy(value: &Value) -> bool {
+			match value {
+				Value::String(s) => !s.is_empty() && *s != "false",
+				Value::Number(n) => *n != 0,
+				Value::Variable(_) => true,
+			}
 		}
 
 		#[derive(Clone, Default)]

--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -34,6 +34,7 @@ fn parse_content(
 		listeners: Vec::new(),
 		variables: Vec::new(),
 		assignments: Vec::new(),
+		conditionals: Vec::new(),
 	};
 	loop {
 		if input.peek_declaration() {
@@ -55,6 +56,21 @@ fn parse_content(
 			block
 				.assignments
 				.push((assignment.variable.0.to_string(), assignment.value));
+		} else if input.peek_conditional() {
+			input.parse::<Token![@]>()?;
+			let keyword = input.call(Ident::parse_any)?;
+			if keyword != "if" {
+				return Err(syn::Error::new(keyword.span(), "expected 'if' after '@'"));
+			}
+			let variable: Variable = input.parse()?;
+			let content;
+			braced!(content in input);
+			let body = parse_content(
+				&content,
+				Ident::new("_conditional", Span::call_site()),
+				Prefix::Element,
+			)?;
+			block.conditionals.push((variable, body));
 		} else {
 			break;
 		}

--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -8,6 +8,7 @@ pub trait Peek {
 	fn peek_variable(&self) -> bool;
 	fn peek_declaration(&self) -> bool;
 	fn peek_assignment(&self) -> bool;
+	fn peek_conditional(&self) -> bool;
 
 	// keywords
 	fn peek_use(&self) -> bool;
@@ -36,6 +37,10 @@ impl Peek for ParseStream<'_> {
 	}
 	fn peek_variable(&self) -> bool {
 		self.peek(Token![$]) && self.peek2(Ident::peek_any)
+	}
+
+	fn peek_conditional(&self) -> bool {
+		self.peek(Token![@])
 	}
 
 	fn peek_use(&self) -> bool {

--- a/src/transform/render/element.rs
+++ b/src/transform/render/element.rs
@@ -1,7 +1,7 @@
 use {
 	crate::data::semantics::{
 		properties::{CuiProperty, Property},
-		Semantics,
+		Semantics, StaticValue, Value,
 	},
 	crate::misc::id_gen::generate_class_id,
 };
@@ -84,6 +84,11 @@ impl Semantics {
 		ancestors.push(element_id);
 		self.render_values(element_id, ancestors);
 
+		// Handle conditional (@if) display
+		if let Some(var_name) = self.groups[element_id].conditional_variable.clone() {
+			self.resolve_conditional(element_id, &var_name, ancestors);
+		}
+
 		// Resolve variable references in listener subtrees (they contain properties
 		// that reference variables from ancestors but aren't rendered as elements)
 		for listener_id in self.groups[element_id].listeners.clone() {
@@ -123,5 +128,32 @@ impl Semantics {
 			.into_iter()
 			.filter(|&group_id| listener_scope == self.groups[group_id].listener_scope)
 			.collect();
+	}
+
+	fn resolve_conditional(&mut self, element_id: usize, var_name: &str, ancestors: &[usize]) {
+		for &ancestor_id in ancestors.iter() {
+			if let Some(&variable_id) = self.groups[ancestor_id].variables.get(var_name) {
+				let is_truthy = match &self.variables[variable_id].0 {
+					Value::Static(StaticValue::String(s)) => !s.is_empty() && s != "false",
+					Value::Static(StaticValue::Number(n)) => *n != 0,
+					Value::Variable(_, Some(sv)) => match sv {
+						StaticValue::String(s) => !s.is_empty() && s != "false",
+						StaticValue::Number(n) => *n != 0,
+					},
+					_ => true,
+				};
+				let display = if is_truthy { "block" } else { "none" };
+				self.groups[element_id].properties.insert(
+					Property::Css("display".to_string()),
+					Value::Static(StaticValue::String(display.to_string())),
+				);
+				self.groups[element_id].conditional_variable_id = Some(variable_id);
+				return;
+			}
+		}
+		panic!(
+			"conditional variable '{}' not found in ancestors",
+			var_name
+		);
 	}
 }

--- a/tests/misc/conditional.rs
+++ b/tests/misc/conditional.rs
@@ -1,0 +1,80 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// @if with a truthy variable — content should be visible
+#[wasm_bindgen_test]
+fn conditional_true() {
+	test_setup! {
+		let $show: "true";
+		@if $show {
+			content {
+				text: "visible";
+			}
+		}
+	}
+	let wrapper = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&wrapper).unwrap().unwrap();
+	assert_ne!(style.get_property_value("display").unwrap(), "none");
+	let content = wrapper.first_element_child().unwrap();
+	assert_eq!(content.inner_html(), "visible");
+}
+
+/// @if with a falsy variable — content should be hidden
+#[wasm_bindgen_test]
+fn conditional_false() {
+	test_setup! {
+		let $show: "false";
+		@if $show {
+			content {
+				text: "hidden";
+			}
+		}
+	}
+	let wrapper = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&wrapper).unwrap().unwrap();
+	assert_eq!(style.get_property_value("display").unwrap(), "none");
+}
+
+/// @if that toggles from false to true on click
+#[wasm_bindgen_test]
+fn conditional_toggle() {
+	test_setup! {
+		let $show: "false";
+		?click {
+			$show: "true";
+		}
+		@if $show {
+			content {
+				text: "now visible";
+			}
+		}
+	}
+	let wrapper = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&wrapper).unwrap().unwrap();
+	assert_eq!(style.get_property_value("display").unwrap(), "none");
+	root.click();
+	let style = window.get_computed_style(&wrapper).unwrap().unwrap();
+	assert_ne!(style.get_property_value("display").unwrap(), "none");
+}
+
+/// @if with empty string — should be falsy (hidden)
+#[wasm_bindgen_test]
+fn conditional_empty_string_is_falsy() {
+	test_setup! {
+		let $val: "";
+		@if $val {
+			content {
+				text: "should be hidden";
+			}
+		}
+	}
+	let wrapper = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&wrapper).unwrap().unwrap();
+	assert_eq!(style.get_property_value("display").unwrap(), "none");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,7 @@ mod data {
 mod misc {
 	mod basics;
 	mod complex;
+	mod conditional;
 	mod events;
 }
 mod properties {


### PR DESCRIPTION
## Summary
- New `@if $var { ... }` syntax for conditional rendering — creates a wrapper `<div>` whose display toggles between `block`/`none` based on variable truthiness
- Full pipeline implementation: parse → AST → analyze → render → compile, with reactive updates via `EffectTarget::Conditional`
- Truthiness rules: non-empty strings (except `"false"`) and non-zero numbers are truthy; empty strings, `"false"`, and `0` are falsy

## How it works
`@if` desugars into a wrapper element with inline `display: block/none` set at compile time. For mutable variables, an `EffectTarget::Conditional` effect is registered so the display updates reactively when the variable changes in a listener.

## Test plan
- [x] `conditional_true` — truthy variable shows content
- [x] `conditional_false` — falsy variable hides content
- [x] `conditional_toggle` — click handler changes variable, display updates reactively
- [x] `conditional_empty_string_is_falsy` — empty string is treated as falsy
- [x] All 47 tests pass (43 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)