### PR TITLE
Implement @media queries for responsive CSS

### DIFF
--- a/src/data/ast.rs
+++ b/src/data/ast.rs
@@ -20,6 +20,7 @@ pub struct Block {
 	pub listeners: Vec<Block>,
 	pub variables: Vec<(String, Value)>,
 	pub assignments: Vec<(String, Value)>,
+	pub media_queries: Vec<(String, Vec<Property>)>,
 }
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]

--- a/src/data/semantics/group.rs
+++ b/src/data/semantics/group.rs
@@ -1,6 +1,6 @@
 use {
 	super::{
-		properties::Property,
+		properties::{Properties, Property},
 		Value,
 	},
 	std::collections::HashMap,
@@ -28,6 +28,9 @@ pub struct Group {
 	pub members: Vec<usize>,
 	pub has_css_properties: bool,
 	pub is_dynamic: bool,
+
+	// for elements with @media queries
+	pub media_rules: Vec<(String, Properties)>,
 }
 impl Group {
 	pub fn new(
@@ -54,6 +57,8 @@ impl Group {
 			members: Vec::new(),
 			has_css_properties: false,
 			is_dynamic: false,
+
+			media_rules: Vec::new(),
 		}
 	}
 
@@ -85,6 +90,8 @@ impl Group {
 			members: Vec::new(),
 			has_css_properties: self.has_css_properties,
 			is_dynamic: false,
+
+			media_rules: Vec::new(),
 		}
 	}
 

--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -29,4 +29,7 @@ pub struct Semantics {
 
 	/// Maps class names to group_ids for classes referenced by `apply:` properties
 	pub apply_targets: HashMap<String, usize>,
+
+	/// Pre-formatted @media CSS rules
+	pub media_styles: Vec<String>,
 }

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -124,6 +124,15 @@ impl Semantics {
 		for block in block.elements {
 			self.create_group_from_block(block, page_id, Some(group_id), listener_scope);
 		}
+		for (expr, props) in block.media_queries {
+			let mut media_props = std::collections::HashMap::new();
+			for prop in props {
+				let value = self.create_semantic_value(&prop.value);
+				let property = Property::new(prop.property);
+				media_props.insert(property, value);
+			}
+			self.groups[group_id].media_rules.push((expr, media_props));
+		}
 	}
 
 	fn create_semantic_value(&self, value: &AstValue) -> Value {

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -51,7 +51,11 @@ impl Semantics {
 		let contents = (self.pages.iter())
 			.map(|page| (page.route, self.groups[page.root_id].html(&self.groups)))
 			.collect();
-		(contents, self.styles.css())
+		let mut css = self.styles.css();
+		for rule in &self.media_styles {
+			css.push_str(rule);
+		}
+		(contents, css)
 	}
 }
 

--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -34,6 +34,7 @@ fn parse_content(
 		listeners: Vec::new(),
 		variables: Vec::new(),
 		assignments: Vec::new(),
+		media_queries: Vec::new(),
 	};
 	loop {
 		if input.peek_declaration() {
@@ -55,6 +56,24 @@ fn parse_content(
 			block
 				.assignments
 				.push((assignment.variable.0.to_string(), assignment.value));
+		} else if input.peek_at_directive() {
+			input.parse::<Token![@]>()?;
+			let keyword = input.call(Ident::parse_any)?;
+			if keyword == "media" {
+				let expr: LitStr = input.parse()?;
+				let content;
+				braced!(content in input);
+				let mut props = Vec::new();
+				while content.peek(Ident::peek_any) {
+					props.push(content.parse::<Property>()?);
+				}
+				block.media_queries.push((expr.value(), props));
+			} else {
+				return Err(syn::Error::new(
+					keyword.span(),
+					format!("unknown @ directive: @{}", keyword),
+				));
+			}
 		} else {
 			break;
 		}

--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -8,6 +8,7 @@ pub trait Peek {
 	fn peek_variable(&self) -> bool;
 	fn peek_declaration(&self) -> bool;
 	fn peek_assignment(&self) -> bool;
+	fn peek_at_directive(&self) -> bool;
 
 	// keywords
 	fn peek_use(&self) -> bool;
@@ -36,6 +37,10 @@ impl Peek for ParseStream<'_> {
 	}
 	fn peek_variable(&self) -> bool {
 		self.peek(Token![$]) && self.peek2(Ident::peek_any)
+	}
+
+	fn peek_at_directive(&self) -> bool {
+		self.peek(Token![@])
 	}
 
 	fn peek_use(&self) -> bool {

--- a/src/transform/render/element.rs
+++ b/src/transform/render/element.rs
@@ -4,6 +4,7 @@ use {
 		Semantics,
 	},
 	crate::misc::id_gen::generate_class_id,
+	crate::transform::compile::css::Css,
 };
 
 impl Semantics {
@@ -83,6 +84,53 @@ impl Semantics {
 
 		ancestors.push(element_id);
 		self.render_values(element_id, ancestors);
+
+		// Handle @media queries: move CSS to class rule, generate @media CSS
+		if !self.groups[element_id].media_rules.is_empty() {
+			let selector = generate_class_id();
+			self.groups[element_id].class_names.push(selector.clone());
+
+			// Move base CSS properties from inline to class rule
+			let css_props: std::collections::HashMap<String, _> = self.groups[element_id]
+				.properties
+				.iter()
+				.filter_map(|(p, v)| {
+					if let Property::Css(name) = p {
+						Some((name.clone(), v.clone()))
+					} else {
+						None
+					}
+				})
+				.collect();
+			if !css_props.is_empty() {
+				self.styles.insert(format!(".{}", selector), css_props);
+			}
+			self.groups[element_id]
+				.properties
+				.retain(|p, _| !matches!(p, Property::Css(_)));
+
+			// Generate @media rules
+			for (expr, props) in self.groups[element_id].media_rules.clone() {
+				let media_css: std::collections::HashMap<String, _> = props
+					.iter()
+					.filter_map(|(p, v)| {
+						if let Property::Css(name) = p {
+							Some((name.clone(), v.clone()))
+						} else {
+							None
+						}
+					})
+					.collect();
+				if !media_css.is_empty() {
+					self.media_styles.push(format!(
+						"@media {}{{.{}{{{}}}}}",
+						expr,
+						selector,
+						media_css.css()
+					));
+				}
+			}
+		}
 
 		// Resolve variable references in listener subtrees (they contain properties
 		// that reference variables from ancestors but aren't rendered as elements)

--- a/tests/properties/media.rs
+++ b/tests/properties/media.rs
@@ -1,0 +1,80 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// @media with max-width larger than viewport — should apply
+#[wasm_bindgen_test]
+fn media_query_applies() {
+	test_setup! {
+		content {
+			text: "hello";
+			color: "blue";
+			@media "(max-width: 1024px)" {
+				color: "red";
+			}
+		}
+	}
+	let content = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&content).unwrap().unwrap();
+	// Default viewport ~800px, so max-width: 1024px should apply
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+}
+
+/// @media with min-width larger than viewport — should NOT apply
+#[wasm_bindgen_test]
+fn media_query_does_not_apply() {
+	test_setup! {
+		content {
+			text: "hello";
+			color: "blue";
+			@media "(min-width: 1920px)" {
+				color: "red";
+			}
+		}
+	}
+	let content = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&content).unwrap().unwrap();
+	// Default viewport ~800px, so min-width: 1920px should NOT apply
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(0, 0, 255)");
+}
+
+/// @media with multiple CSS properties
+#[wasm_bindgen_test]
+fn media_query_multiple_props() {
+	test_setup! {
+		content {
+			text: "hello";
+			color: "blue";
+			font-size: "20px";
+			@media "(max-width: 1024px)" {
+				color: "red";
+				font-size: "14px";
+			}
+		}
+	}
+	let content = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&content).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+	assert_eq!(style.get_property_value("font-size").unwrap(), "14px");
+}
+
+/// Element with @media but no base CSS properties
+#[wasm_bindgen_test]
+fn media_query_no_base_css() {
+	test_setup! {
+		content {
+			text: "hello";
+			@media "(max-width: 1024px)" {
+				color: "green";
+			}
+		}
+	}
+	let content = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&content).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(0, 128, 0)");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod media;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- New `@media "expr" { props }` syntax for responsive design — generates CSS `@media` rules
- Expression is a string literal (e.g., `"(max-width: 768px)"`) to avoid CSS expression parsing complexity
- When an element has `@media` rules, its base CSS properties move from inline styles to a class rule, avoiding specificity conflicts with the `@media` override
- Purely CSS-level feature — no Wasm codegen needed

## Example
```
content {
    font-size: "20px";
    color: "blue";
    @media "(max-width: 768px)" {
        font-size: "14px";
        color: "red";
    }
}
```

## Test plan
- [x] `media_query_applies` — @media with max-width > viewport applies override styles
- [x] `media_query_does_not_apply` — @media with min-width > viewport preserves base styles
- [x] `media_query_multiple_props` — multiple CSS properties in single @media rule
- [x] `media_query_no_base_css` — @media-only styles without base CSS properties
- [x] All 47 tests pass (43 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)