### PR TITLE
Add tag: property and $value built-in variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ features = [
 	"HtmlCollection",
 	"HtmlElement",
 	"HtmlHeadElement",
+	"HtmlInputElement",
 	"Location",
 	"Node",
 	"NodeList",

--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -15,6 +15,7 @@ pub enum CuiProperty {
 	Tooltip,
 	Image,
 	Apply,
+	Tag,
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Tag => quote! { Tag },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -42,6 +42,7 @@ impl Property {
 					"tooltip" => CuiProperty::Tooltip,
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
+					"tag" => CuiProperty::Tag,
 
 					property => panic!(" property not recognized: {}", property),
 				}),
@@ -62,6 +63,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Tag => quote! { Tag },
 			}
 		} else {
 			quote! {}

--- a/src/data/semantics/value.rs
+++ b/src/data/semantics/value.rs
@@ -6,6 +6,7 @@ pub enum Value {
 	Variable(usize, Option<StaticValue>),
 	UnrenderedVariable(String),
 	ClassRef(String),
+	EventValue,
 }
 
 #[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -107,19 +107,15 @@ impl Semantics {
 			.chain(self.groups[group_id].assignments.iter())
 			.filter_map(|(_, variable_id)| {
 				if let (value, Some(mutable_id)) = &self.variables[*variable_id] {
-					Some((value, mutable_id))
+					Some((value.clone(), *mutable_id))
 				} else {
 					None
 				}
 			})
+			.collect::<Vec<_>>()
+			.into_iter()
 			.map(|(value, mutable_id)| {
-				let type_ = match self.get_static(value) {
-					StaticValue::Number(_) => quote! { Number },
-					StaticValue::String(_) => quote! { String },
-				};
-				let value = quote! {
-					Value::#type_(#value)
-				};
+				let value = self.compiled_dynamic_value(&value);
 				quote! {
 					state[#mutable_id].0 = #value;
 					for Effect { property, target } in &state[#mutable_id].1 {
@@ -206,6 +202,16 @@ impl Semantics {
 			if let (_, Some(mutable_id)) = self.variables[variable_id] {
 				return quote! { state[#mutable_id].0.clone() };
 			}
+		}
+		if let Value::EventValue = value {
+			return quote! {
+				Value::String(Box::leak(
+					e.target().unwrap()
+						.dyn_into::<web_sys::HtmlInputElement>().unwrap()
+						.value()
+						.into_boxed_str()
+				))
+			};
 		}
 		// Static value — construct the runtime Value enum
 		let type_ = match self.get_static(value) {

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -2,7 +2,7 @@ mod initialize;
 mod runtime;
 
 use {
-	crate::data::semantics::{Semantics, StaticValue},
+	crate::data::semantics::{Semantics, StaticValue, Value},
 	proc_macro2::{Span, TokenStream},
 	quote::{format_ident, quote, quote_spanned},
 };
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Tag,
 		}
 
 		#[derive(Clone, Debug)]
@@ -116,6 +117,11 @@ impl Semantics {
 	pub fn get_mutables(&self) -> TokenStream {
 		let mut mutables = vec![quote! {}; self.mutable_count];
 		for (value, mutable_id) in &self.variables {
+			// Skip EventValue — it's a runtime-only value (e.g. $value in a listener),
+			// not a valid initializer for mutable state
+			if let Value::EventValue = value {
+				continue;
+			}
 			if let &Some(mutable_id) = mutable_id {
 				// if !mutables[mutable_id].is_empty() {
 				// 	panic!("multiple default values for same mutable")

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -11,7 +11,9 @@ impl Semantics {
 				let window = web_sys::window().unwrap();
 				let document = &window.document().unwrap();
 				for element in &group.elements {
-					let tag = if element.properties.get(&Property::Link).is_some() {
+					let tag = if let Some(Value::String(t)) = element.properties.get(&Property::Tag) {
+						t
+					} else if element.properties.get(&Property::Link).is_some() {
 						"a"
 					} else {
 						"div"
@@ -122,6 +124,7 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Tag => (),
 				}
 			}
 		}

--- a/src/transform/render/element.rs
+++ b/src/transform/render/element.rs
@@ -1,7 +1,7 @@
 use {
 	crate::data::semantics::{
 		properties::{CuiProperty, Property},
-		Semantics,
+		Semantics, StaticValue, Value,
 	},
 	crate::misc::id_gen::generate_class_id,
 };
@@ -95,7 +95,11 @@ impl Semantics {
 		}
 		ancestors.pop();
 
-		self.groups[element_id].tag = if self.groups[element_id]
+		self.groups[element_id].tag = if let Some(Value::Static(StaticValue::String(tag))) =
+			self.groups[element_id].properties.get(&Property::Cui(CuiProperty::Tag))
+		{
+			Box::leak(tag.clone().into_boxed_str())
+		} else if self.groups[element_id]
 			.properties
 			.contains_key(&Property::Cui(CuiProperty::Link))
 		{

--- a/src/transform/render/value.rs
+++ b/src/transform/render/value.rs
@@ -20,6 +20,7 @@ impl fmt::Display for Value {
 				Value::Variable(variable_id, None) => format!("<{}>", variable_id),
 				Value::UnrenderedVariable(_) => "@variable".to_string(),
 				Value::ClassRef(name) => format!(".{}", name),
+				Value::EventValue => "$value".to_string(),
 			}
 		)
 	}
@@ -28,7 +29,7 @@ impl fmt::Display for Value {
 impl ToTokens for Value {
 	fn to_tokens(&self, tokens: &mut TokenStream) {
 		match self {
-			Value::ClassRef(_) => {}, // ClassRef is not a runtime value
+			Value::ClassRef(_) | Value::EventValue => {}, // not runtime-literal values
 			_ => self.to_string().to_tokens(tokens),
 		}
 	}
@@ -38,6 +39,16 @@ impl Semantics {
 	pub fn render_values(&mut self, element_id: usize, ancestors: &[usize]) {
 		for variable_id in self.groups[element_id]
 			.variables
+			.values()
+			.cloned()
+			.collect::<Vec<_>>()
+		{
+			let rendered = self.render_value(self.variables[variable_id].0.clone(), ancestors);
+			self.variables[variable_id].0 = rendered;
+		}
+
+		for variable_id in self.groups[element_id]
+			.assignments
 			.values()
 			.cloned()
 			.collect::<Vec<_>>()
@@ -71,6 +82,10 @@ impl Semantics {
 							},
 						);
 					}
+				}
+				// Built-in variable: $value reads the event target's value property
+				if identifier == "value" {
+					return Value::EventValue;
 				}
 				panic!("unable to render variable '{}' from ancestors", identifier)
 			}
@@ -184,6 +199,7 @@ impl Semantics {
 				panic!("cannot get static value of unrendered variable")
 			}
 			Value::ClassRef(name) => StaticValue::String(format!(".{}", name)),
+			Value::EventValue => StaticValue::String(String::new()),
 		}
 	}
 }

--- a/tests/data/event_value.rs
+++ b/tests/data/event_value.rs
@@ -1,0 +1,79 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn event_value_basic() {
+	test_setup! {
+		let $text: "";
+		input_field {
+			tag: "input";
+			?click {
+				$text: $value;
+			}
+		}
+		output {
+			text: $text;
+		}
+	}
+	let input_el = root.children().item(0).unwrap();
+	let input = input_el.dyn_ref::<web_sys::HtmlInputElement>().unwrap();
+	input.set_value("hello");
+	input_el.dyn_ref::<HtmlElement>().unwrap().click();
+	let output = root.children().item(1).unwrap();
+	assert_eq!(output.inner_html(), "hello");
+}
+
+#[wasm_bindgen_test]
+fn event_value_updates_multiple() {
+	test_setup! {
+		let $text: "";
+		input_field {
+			tag: "input";
+			?click {
+				$text: $value;
+			}
+		}
+		display {
+			text: $text;
+		}
+	}
+	let input_el = root.children().item(0).unwrap();
+	let input = input_el.dyn_ref::<web_sys::HtmlInputElement>().unwrap();
+
+	input.set_value("first");
+	input_el.dyn_ref::<HtmlElement>().unwrap().click();
+	let display = root.children().item(1).unwrap();
+	assert_eq!(display.inner_html(), "first");
+
+	input.set_value("second");
+	input_el.dyn_ref::<HtmlElement>().unwrap().click();
+	let display = root.children().item(1).unwrap();
+	assert_eq!(display.inner_html(), "second");
+}
+
+#[wasm_bindgen_test]
+fn event_value_empty_string() {
+	test_setup! {
+		let $text: "initial";
+		input_field {
+			tag: "input";
+			?click {
+				$text: $value;
+			}
+		}
+		display {
+			text: $text;
+		}
+	}
+	let input_el = root.children().item(0).unwrap();
+	// input.value() is "" by default for a fresh input element
+	input_el.dyn_ref::<HtmlElement>().unwrap().click();
+	let display = root.children().item(1).unwrap();
+	assert_eq!(display.inner_html(), "");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ mod classes {
 mod data {
 	mod apply;
 	mod dynamic;
+	mod event_value;
 	mod r#static;
 }
 mod misc {


### PR DESCRIPTION
## Summary
- Adds `tag:` CUI property to set an element's HTML tag (e.g. `tag: "input"` creates `<input>` instead of `<div>`)
- Adds `$value` built-in variable that reads `e.target().value` inside event listeners, enabling form input binding
- Includes `HtmlInputElement` in web-sys features for runtime `dyn_into` cast
- Uses `Box::leak` for runtime `String` → `&'static str` conversion (pragmatic tradeoff for MVP)

### Example
```
let $text: "";
input_field {
    tag: "input";
    ?click {
        $text: $value;
    }
}
output {
    text: $text;
}
```

## Test plan
- [x] `event_value_basic` — reads input value on click, displays in sibling element
- [x] `event_value_updates_multiple` — value updates correctly across multiple clicks
- [x] `event_value_empty_string` — empty input value correctly overrides initial text
- [x] All 43 existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)