### PR TITLE
Add ?init pseudo-event for element initialization

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -77,8 +77,8 @@ impl Semantics {
 		quote! {
 			#( #elements )*
 			#( #classes )*
-			#listeners
 			#( #variables )*
+			#listeners
 		}
 	}
 
@@ -90,11 +90,18 @@ impl Semantics {
 					return quote! {};
 				}
 
-				let event = match &**self.groups[listener_id]
+				let event_name = &**self.groups[listener_id]
 					.name
 					.as_ref()
-					.expect("every listener should have an event id")
-				{
+					.expect("every listener should have an event id");
+
+				// Init pseudo-event: execute rules immediately during initialization.
+				// No event binding — the code runs inline as part of element setup.
+				if event_name == "init" {
+					return rules;
+				}
+
+				let event = match event_name {
 					"blur" => quote! { set_onblur },
 					"focus" => quote! { set_onfocus },
 					"click" => quote! { set_onclick },

--- a/tests/misc/init.rs
+++ b/tests/misc/init.rs
@@ -1,0 +1,60 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn init_sets_text() {
+	test_setup! {
+		?init {
+			text: "initialized";
+		}
+	}
+	assert_eq!(root.inner_html(), "initialized");
+}
+
+#[wasm_bindgen_test]
+fn init_sets_variable() {
+	test_setup! {
+		let $text: "before";
+		text: $text;
+		?init {
+			$text: "after";
+		}
+	}
+	assert_eq!(root.inner_html(), "after");
+}
+
+#[wasm_bindgen_test]
+fn init_on_child() {
+	test_setup! {
+		child {
+			?init {
+				text: "child initialized";
+			}
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.inner_html(), "child initialized");
+}
+
+#[wasm_bindgen_test]
+fn init_with_click() {
+	test_setup! {
+		let $text: "before";
+		text: $text;
+		?init {
+			$text: "initialized";
+		}
+		?click {
+			$text: "clicked";
+		}
+	}
+	assert_eq!(root.inner_html(), "initialized");
+	root.click();
+	assert_eq!(root.inner_html(), "clicked");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod init;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds `?init { ... }` pseudo-event that runs immediately during element creation
- No DOM event binding — code executes inline as part of element setup
- Enables initialization patterns: default state, dynamic children, setup logic
- Reorders `compiled_element` to register effects before listeners so `?init` can trigger reactive updates

### Example
```
let $text: "loading";
text: $text;
?init {
    $text: "ready";
}
?click {
    $text: "clicked";
}
```

## Test plan
- [x] `init_sets_text` — ?init sets element text immediately
- [x] `init_sets_variable` — ?init changes mutable variable, propagates to text binding
- [x] `init_on_child` — ?init works on child elements
- [x] `init_with_click` — ?init and ?click coexist, init runs first, click works after
- [x] All 43 existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)