### PR TITLE
Implement localStorage persistence for mutable variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ features = [
 	"Location",
 	"Node",
 	"NodeList",
+	"Storage",
 	"Window",
 ]
 version = "^0.3.60"

--- a/src/data/ast.rs
+++ b/src/data/ast.rs
@@ -18,7 +18,7 @@ pub struct Block {
 	pub elements: Vec<Block>,
 	pub classes: Vec<Block>,
 	pub listeners: Vec<Block>,
-	pub variables: Vec<(String, Value)>,
+	pub variables: Vec<(String, Value, bool)>, // (name, value, persist)
 	pub assignments: Vec<(String, Value)>,
 }
 

--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -29,4 +29,9 @@ pub struct Semantics {
 
 	/// Maps class names to group_ids for classes referenced by `apply:` properties
 	pub apply_targets: HashMap<String, usize>,
+
+	/// Maps variable_id → variable_name for variables marked with `persist`
+	pub persistent_variables: HashMap<usize, String>,
+	/// Maps mutable_id → localStorage key for persistent variables (built after render)
+	pub persistent_mutables: HashMap<usize, String>,
 }

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -47,10 +47,14 @@ impl Semantics {
 		);
 
 		let variables = (block.variables.iter())
-			.map(|(identifier, value)| {
+			.map(|(identifier, value, persist)| {
 				let value = self.create_semantic_value(value);
 				self.variables.push((value, None));
-				(identifier.clone(), self.variables.len() - 1)
+				let var_id = self.variables.len() - 1;
+				if *persist {
+					self.persistent_variables.insert(var_id, identifier.clone());
+				}
+				(identifier.clone(), var_id)
 			})
 			.collect();
 

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -120,8 +120,23 @@ impl Semantics {
 				let value = quote! {
 					Value::#type_(#value)
 				};
+
+				let persist_save = if let Some(key) = self.persistent_mutables.get(mutable_id) {
+					quote! {
+						if let Value::String(s) = &state[#mutable_id].0 {
+							let window = web_sys::window().unwrap();
+							if let Ok(Some(storage)) = window.local_storage() {
+								storage.set_item(#key, s).ok();
+							}
+						}
+					}
+				} else {
+					quote! {}
+				};
+
 				quote! {
 					state[#mutable_id].0 = #value;
+					#persist_save
 					for Effect { property, target } in &state[#mutable_id].1 {
 						match target {
 							EffectTarget::Element(element) => {

--- a/src/transform/compile/wasm/initialize/mod.rs
+++ b/src/transform/compile/wasm/initialize/mod.rs
@@ -12,6 +12,9 @@ impl Semantics {
 		if rules.is_empty() {
 			return quote! {};
 		}
+
+		let persistent_apply = self.compiled_persistent_apply();
+
 		quote! {
 			CLASSES.with(|classes| {
 				let mut classes = classes.borrow_mut();
@@ -27,7 +30,46 @@ impl Semantics {
 					.dyn_into::<HtmlElement>()
 					.unwrap();
 				#rules
+				#persistent_apply
 			});
+		}
+	}
+
+	/// After all effects are registered, apply current values for persistent
+	/// variables. These may differ from compile-time defaults if localStorage
+	/// had a stored value.
+	fn compiled_persistent_apply(&self) -> TokenStream {
+		let applies: Vec<TokenStream> = self
+			.persistent_mutables
+			.keys()
+			.map(|mutable_id| {
+				quote! {
+					for Effect { property, target } in &state[#mutable_id].1 {
+						match target {
+							EffectTarget::Element(element) => {
+								render_property(element, property, state[#mutable_id].0.clone());
+							}
+							EffectTarget::Class(class_name) => {
+								let elements = document.get_elements_by_class_name(class_name);
+								for i in 0..elements.length() {
+									let element = elements
+										.item(i)
+										.unwrap()
+										.dyn_into::<HtmlElement>()
+										.unwrap();
+									render_property(&element, property, state[#mutable_id].0.clone());
+								}
+							}
+						}
+					}
+				}
+			})
+			.collect();
+
+		if applies.is_empty() {
+			quote! {}
+		} else {
+			quote! { #( #applies )* }
 		}
 	}
 }

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -117,17 +117,39 @@ impl Semantics {
 		let mut mutables = vec![quote! {}; self.mutable_count];
 		for (value, mutable_id) in &self.variables {
 			if let &Some(mutable_id) = mutable_id {
-				// if !mutables[mutable_id].is_empty() {
-				// 	panic!("multiple default values for same mutable")
-				// }
+				// Only use the first variable for each mutable_id (the declaration).
+				// Assignment variables share the same mutable_id but have different
+				// values — skip them to avoid overwriting the declaration's default.
+				if !mutables[mutable_id].is_empty() {
+					continue;
+				}
+
 				let type_ = match self.get_static(value) {
 					StaticValue::Number(_) => quote! { Number },
 					StaticValue::String(_) => quote! { String },
-					// StaticValue::Color(_, _, _, _) => quote! { String },
 				};
-				mutables[mutable_id] = quote! {
-					Value::#type_(#value)
-				};
+
+				if let Some(key) = self.persistent_mutables.get(&mutable_id) {
+					// Load from localStorage if available, fall back to default
+					mutables[mutable_id] = quote! {
+						{
+							let window = web_sys::window().unwrap();
+							if let Ok(Some(storage)) = window.local_storage() {
+								if let Ok(Some(stored)) = storage.get_item(#key) {
+									Value::String(Box::leak(stored.into_boxed_str()))
+								} else {
+									Value::#type_(#value)
+								}
+							} else {
+								Value::#type_(#value)
+							}
+						}
+					};
+				} else {
+					mutables[mutable_id] = quote! {
+						Value::#type_(#value)
+					};
+				}
 			}
 		}
 		quote! { vec![ #( (#mutables, Vec::new()), )* ] }

--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -38,10 +38,21 @@ fn parse_content(
 	loop {
 		if input.peek_declaration() {
 			input.parse::<Token![let]>()?;
+			// Check for optional 'persist' modifier: let persist $var: value;
+			let persist = !input.peek(Token![$]);
+			if persist {
+				let keyword = input.call(Ident::parse_any)?;
+				if keyword != "persist" {
+					return Err(syn::Error::new(
+						keyword.span(),
+						"expected 'persist' or '$' after 'let'",
+					));
+				}
+			}
 			let assignment = input.parse::<Assignment>()?;
 			block
 				.variables
-				.push((assignment.variable.0.to_string(), assignment.value));
+				.push((assignment.variable.0.to_string(), assignment.value, persist));
 		} else if input.peek_property() {
 			block.properties.push(input.parse()?);
 		} else if input.peek_element_block() {

--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -29,7 +29,9 @@ impl Peek for ParseStream<'_> {
 		self.peek(Token![?]) && self.peek2(Ident::peek_any) && self.peek3(Brace)
 	}
 	fn peek_declaration(&self) -> bool {
-		self.peek(Token![let]) && self.peek2(Token![$]) && self.peek3(Ident::peek_any)
+		self.peek(Token![let])
+			&& ((self.peek2(Token![$]) && self.peek3(Ident::peek_any))
+				|| (self.peek2(Ident::peek_any) && self.peek3(Token![$])))
 	}
 	fn peek_assignment(&self) -> bool {
 		self.peek_variable() && self.peek3(Token![:])

--- a/src/transform/render/mod.rs
+++ b/src/transform/render/mod.rs
@@ -27,6 +27,24 @@ impl Semantics {
 			self.pages[i].title = title;
 			self.render_element(page_group_id, ancestors);
 		}
+
+		// Ensure persistent variables always have mutable_ids, even without
+		// listener assignments. This makes them reactive so localStorage
+		// values can be applied at startup.
+		for (&var_id, _) in self.persistent_variables.clone().iter() {
+			if self.variables[var_id].1.is_none() {
+				self.variables[var_id].1 = Some(generate_mutable_id());
+			}
+		}
+
 		self.mutable_count = generate_mutable_id();
+
+		// Build mutable_id → localStorage key mapping for persistent variables
+		for (&var_id, name) in self.persistent_variables.clone().iter() {
+			if let (_, Some(mutable_id)) = &self.variables[var_id] {
+				self.persistent_mutables
+					.insert(*mutable_id, format!("cui:{}", name));
+			}
+		}
 	}
 }

--- a/tests/data/persist.rs
+++ b/tests/data/persist.rs
@@ -1,0 +1,56 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn persist_loads_from_storage() {
+	let window = web_sys::window().unwrap();
+	let storage = window.local_storage().unwrap().unwrap();
+	storage.set_item("cui:theme", "dark").unwrap();
+
+	test_setup! {
+		let persist $theme: "light";
+		text: $theme;
+	}
+	assert_eq!(root.inner_html(), "dark");
+	storage.remove_item("cui:theme").unwrap();
+}
+
+#[wasm_bindgen_test]
+fn persist_saves_on_change() {
+	let window = web_sys::window().unwrap();
+	let storage = window.local_storage().unwrap().unwrap();
+	storage.remove_item("cui:theme").unwrap();
+
+	test_setup! {
+		let persist $theme: "light";
+		text: $theme;
+		?click {
+			$theme: "dark";
+		}
+	}
+	assert_eq!(root.inner_html(), "light");
+	root.click();
+	assert_eq!(root.inner_html(), "dark");
+	assert_eq!(storage.get_item("cui:theme").unwrap().unwrap(), "dark");
+	storage.remove_item("cui:theme").unwrap();
+}
+
+#[wasm_bindgen_test]
+fn persist_uses_default_when_empty() {
+	let window = web_sys::window().unwrap();
+	let storage = window.local_storage().unwrap().unwrap();
+	storage.remove_item("cui:color").unwrap();
+
+	test_setup! {
+		let persist $color: "red";
+		text: $color;
+	}
+	assert_eq!(root.inner_html(), "red");
+	storage.remove_item("cui:color").unwrap();
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ mod classes {
 mod data {
 	mod apply;
 	mod dynamic;
+	mod persist;
 	mod r#static;
 }
 mod misc {


### PR DESCRIPTION
## Summary
- Adds `let persist $var: value;` syntax that saves variable values to localStorage on change and loads them on startup
- Persistent variables are automatically reactive (get mutable_ids) even without listener assignments
- Fixes a pre-existing bug where assignment variables could overwrite declaration defaults in `get_mutables`
- After effects are registered, persistent variables apply their localStorage-loaded values to the DOM via `compiled_persistent_apply`

## Changes
- **Parser**: `peek_declaration` accepts `let persist $var` syntax; parse extracts persist flag
- **AST**: `variables` tuple extended with `bool` persist flag
- **Analyze**: Tracks persistent variables in `Semantics::persistent_variables`
- **Render**: Assigns mutable_ids to persistent vars unconditionally; builds `persistent_mutables` mapping
- **Codegen (get_mutables)**: Loads from localStorage with `cui:` prefix key, falls back to default; skips duplicate mutable_id entries
- **Codegen (dynamic)**: Saves to localStorage after variable assignment in listeners
- **Codegen (document)**: `compiled_persistent_apply` applies localStorage values to all registered effects after init
- **Cargo.toml**: Added `Storage` to web-sys features

## Test plan
- [x] `persist_loads_from_storage` — sets localStorage before init, verifies value is loaded
- [x] `persist_saves_on_change` — clicks to change value, verifies localStorage is updated
- [x] `persist_uses_default_when_empty` — no localStorage entry, verifies default is used
- [x] All 43 existing tests still pass (46 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)