### PR TITLE
Add hash-based routing with /path block syntax

### DIFF
--- a/src/data/ast.rs
+++ b/src/data/ast.rs
@@ -9,6 +9,7 @@ pub enum Prefix {
 	Element,
 	Class,
 	Listener,
+	Route,
 }
 
 pub struct Block {

--- a/src/data/semantics/group.rs
+++ b/src/data/semantics/group.rs
@@ -22,6 +22,7 @@ pub struct Group {
 	pub tag: &'static str,
 	pub member_of: Vec<usize>,
 	pub class_names: Vec<String>,
+	pub route: Option<String>,
 
 	// for class groups
 	pub selector: Option<String>,
@@ -49,6 +50,7 @@ impl Group {
 			tag: "div",
 			member_of: Vec::new(),
 			class_names: Vec::new(),
+			route: None,
 
 			selector: None,
 			members: Vec::new(),
@@ -80,6 +82,7 @@ impl Group {
 			tag: "div",
 			member_of: vec![source_id],
 			class_names: Vec::new(),
+			route: None,
 
 			selector: None,
 			members: Vec::new(),

--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -29,4 +29,7 @@ pub struct Semantics {
 
 	/// Maps class names to group_ids for classes referenced by `apply:` properties
 	pub apply_targets: HashMap<String, usize>,
+
+	/// Route group IDs for hash-based routing (ordered, first is default)
+	pub routes: Vec<(String, usize)>,
 }

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -68,7 +68,7 @@ impl Semantics {
 			let parent = &mut self.groups[parent_id];
 			let current_scope = listener_scope;
 			match block.prefix {
-				Prefix::Element => {
+				Prefix::Element | Prefix::Route => {
 					parent.elements.push(group_id);
 				}
 				Prefix::Class => {
@@ -83,8 +83,11 @@ impl Semantics {
 					parent.listeners.push(group_id);
 				}
 			}
-			let mut group = Group::new(Some(identifier), current_scope, variables);
+			let mut group = Group::new(Some(identifier.clone()), current_scope, variables);
 			group.assignments = assignments;
+			if let Prefix::Route = block.prefix {
+				group.route = Some(identifier);
+			}
 			group
 		} else {
 			page_id = Some(self.pages.len());

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -48,34 +48,54 @@ impl Semantics {
 	}
 
 	pub fn html_parts(&self) -> (HashMap<&str, String>, String) {
+		let first_route = self.routes.first().map(|(name, _)| name.as_str());
 		let contents = (self.pages.iter())
-			.map(|page| (page.route, self.groups[page.root_id].html(&self.groups)))
+			.map(|page| (page.route, self.groups[page.root_id].html(&self.groups, first_route)))
 			.collect();
 		(contents, self.styles.css())
 	}
 }
 
 impl Group {
-	fn html(&self, groups: &[Group]) -> String {
+	fn html(&self, groups: &[Group], first_route: Option<&str>) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
-		let attributes = [
-			("style", &*self.properties.css()),
-			("class", &*self.class_names.join(" ")),
+
+		// Build style string — routes get display:none unless they're the default
+		let mut style = self.properties.css();
+		if let Some(route_name) = &self.route {
+			let is_default = first_route == Some(route_name.as_str());
+			if !is_default {
+				if style.is_empty() {
+					style = "display:none".to_string();
+				} else {
+					style = format!("{};display:none", style);
+				}
+			}
+		}
+
+		let mut attrs: Vec<(&str, String)> = vec![
+			("style", style),
+			("class", self.class_names.join(" ")),
 			(
 				"href",
-				&*link
-					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+				link.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),
-		]
-		.iter()
-		.filter(|(_, value)| !value.is_empty())
-		.map(|(attribute, value)| format!(" {}='{}'", attribute, value))
-		.collect::<String>();
+		];
+
+		if let Some(route_name) = &self.route {
+			attrs.push(("data-route", route_name.clone()));
+		}
+
+		let attributes = attrs
+			.iter()
+			.filter(|(_, value)| !value.is_empty())
+			.map(|(attribute, value)| format!(" {}='{}'", attribute, value))
+			.collect::<String>();
 
 		let children = (self.elements.iter())
 			.filter(|&&element_id| groups[element_id].is_compiled())
-			.map(|&child_id| groups[child_id].html(groups))
+			.map(|&child_id| groups[child_id].html(groups, first_route))
 			.collect::<String>();
 
 		let contents = format!(

--- a/src/transform/compile/wasm/initialize/mod.rs
+++ b/src/transform/compile/wasm/initialize/mod.rs
@@ -9,25 +9,105 @@ use {crate::data::semantics::Semantics, proc_macro2::TokenStream, quote::quote};
 impl Semantics {
 	pub fn document(&self) -> TokenStream {
 		let rules = self.compiled_element(self.pages[0].root_id);
-		if rules.is_empty() {
+		let router = self.compiled_router();
+
+		if rules.is_empty() && router.is_empty() {
 			return quote! {};
 		}
-		quote! {
-			CLASSES.with(|classes| {
-				let mut classes = classes.borrow_mut();
-				let window = web_sys::window().expect("getting window");
-				let document = &window.document().expect("getting `window.document`");
-				let head = &document.head().expect("getting `window.document.head`");
-				let body = &document.body().expect("getting `window.document.body`");
 
-				let element = body
-					.children()
-					.item(0)
-					.expect("body should have a root element")
-					.dyn_into::<HtmlElement>()
-					.unwrap();
-				#rules
-			});
+		let classes_block = if rules.is_empty() {
+			quote! {}
+		} else {
+			quote! {
+				CLASSES.with(|classes| {
+					let mut classes = classes.borrow_mut();
+					let window = web_sys::window().expect("getting window");
+					let document = &window.document().expect("getting `window.document`");
+					let head = &document.head().expect("getting `window.document.head`");
+					let body = &document.body().expect("getting `window.document.body`");
+
+					let element = body
+						.children()
+						.item(0)
+						.expect("body should have a root element")
+						.dyn_into::<HtmlElement>()
+						.unwrap();
+					#rules
+				});
+			}
+		};
+
+		quote! {
+			#classes_block
+			#router
+		}
+	}
+
+	/// Generate a hashchange-based router that shows/hides route elements.
+	fn compiled_router(&self) -> TokenStream {
+		if self.routes.is_empty() {
+			return quote! {};
+		}
+
+		let route_names: Vec<&str> = self.routes.iter().map(|(name, _)| name.as_str()).collect();
+		let default_route = &route_names[0];
+
+		quote! {
+			{
+				let window = web_sys::window().unwrap();
+				let document = window.document().unwrap();
+
+				// Initial route from hash
+				let hash = window.location().hash().unwrap_or_default();
+				let initial_route = if hash.len() > 1 {
+					&hash[1..]  // strip leading #
+				} else {
+					#default_route
+				};
+
+				// Apply initial route
+				let route_names: Vec<&str> = vec![#( #route_names ),*];
+				for route_name in &route_names {
+					let selector = format!("[data-route='{}']", route_name);
+					if let Some(el) = document.query_selector(&selector).unwrap() {
+						let el = el.dyn_into::<HtmlElement>().unwrap();
+						if *route_name == initial_route {
+							el.style().set_property("display", "").unwrap();
+						} else {
+							el.style().set_property("display", "none").unwrap();
+						}
+					}
+				}
+
+				// Listen for hashchange
+				let route_names_clone: Vec<String> = route_names.iter().map(|s| s.to_string()).collect();
+				let closure = Closure::wrap(Box::new(move |_: Event| {
+					let window = web_sys::window().unwrap();
+					let document = window.document().unwrap();
+					let hash = window.location().hash().unwrap_or_default();
+					let target = if hash.len() > 1 {
+						hash[1..].to_string()
+					} else {
+						route_names_clone[0].clone()
+					};
+					for route_name in &route_names_clone {
+						let selector = format!("[data-route='{}']", route_name);
+						if let Some(el) = document.query_selector(&selector).unwrap() {
+							let el = el.dyn_into::<HtmlElement>().unwrap();
+							if *route_name == target {
+								el.style().set_property("display", "").unwrap();
+							} else {
+								el.style().set_property("display", "none").unwrap();
+							}
+						}
+					}
+				}) as Box<dyn FnMut(Event)>);
+				window.add_event_listener_with_callback(
+					"hashchange",
+					closure.as_ref().unchecked_ref(),
+				).unwrap();
+				closure.forget();
+			}
 		}
 	}
 }

--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -50,6 +50,8 @@ fn parse_content(
 			block.classes.push(input.parse()?);
 		} else if input.peek_listener_block() {
 			block.listeners.push(input.parse()?);
+		} else if input.peek_route_block() {
+			block.elements.push(input.parse()?);
 		} else if input.peek_assignment() {
 			let assignment = input.parse::<Assignment>()?;
 			block
@@ -70,6 +72,9 @@ impl Parse for Block {
 		} else if input.peek(Token![?]) {
 			input.parse::<Token![?]>()?;
 			Prefix::Listener
+		} else if input.peek(Token![/]) {
+			input.parse::<Token![/]>()?;
+			Prefix::Route
 		} else {
 			Prefix::Element
 		};

--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -5,6 +5,7 @@ pub trait Peek {
 	fn peek_element_block(&self) -> bool;
 	fn peek_class_block(&self) -> bool;
 	fn peek_listener_block(&self) -> bool;
+	fn peek_route_block(&self) -> bool;
 	fn peek_variable(&self) -> bool;
 	fn peek_declaration(&self) -> bool;
 	fn peek_assignment(&self) -> bool;
@@ -27,6 +28,9 @@ impl Peek for ParseStream<'_> {
 	}
 	fn peek_listener_block(&self) -> bool {
 		self.peek(Token![?]) && self.peek2(Ident::peek_any) && self.peek3(Brace)
+	}
+	fn peek_route_block(&self) -> bool {
+		self.peek(Token![/]) && self.peek2(Ident::peek_any) && self.peek3(Brace)
 	}
 	fn peek_declaration(&self) -> bool {
 		self.peek(Token![let]) && self.peek2(Token![$]) && self.peek3(Ident::peek_any)

--- a/src/transform/render/mod.rs
+++ b/src/transform/render/mod.rs
@@ -28,5 +28,14 @@ impl Semantics {
 			self.render_element(page_group_id, ancestors);
 		}
 		self.mutable_count = generate_mutable_id();
+
+		// Collect route groups for hash-based routing
+		for page in &self.pages {
+			for &element_id in &self.groups[page.root_id].elements {
+				if let Some(route) = &self.groups[element_id].route {
+					self.routes.push((route.clone(), element_id));
+				}
+			}
+		}
 	}
 }

--- a/tests/misc/routing.rs
+++ b/tests/misc/routing.rs
@@ -1,0 +1,83 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+// Route blocks create container elements with data-route attributes
+#[wasm_bindgen_test]
+fn route_creates_elements() {
+	test_setup! {
+		/home {
+			text: "Home";
+		}
+		/about {
+			text: "About";
+		}
+	}
+	// Both routes should be in the DOM
+	let home = root.children().item(0).unwrap().dyn_into::<HtmlElement>().unwrap();
+	let about = root.children().item(1).unwrap().dyn_into::<HtmlElement>().unwrap();
+	assert_eq!(home.inner_html(), "Home");
+	assert_eq!(about.inner_html(), "About");
+	assert_eq!(home.get_attribute("data-route").unwrap(), "home");
+	assert_eq!(about.get_attribute("data-route").unwrap(), "about");
+}
+
+// First route should be visible by default, others hidden
+#[wasm_bindgen_test]
+fn route_default_visibility() {
+	// Clean hash state
+	let w = web_sys::window().unwrap();
+	w.location().set_hash("").unwrap();
+
+	test_setup! {
+		/home {
+			text: "Home";
+		}
+		/about {
+			text: "About";
+		}
+	}
+	let home = root.children().item(0).unwrap().dyn_into::<HtmlElement>().unwrap();
+	let about = root.children().item(1).unwrap().dyn_into::<HtmlElement>().unwrap();
+
+	let home_display = window.get_computed_style(&home).unwrap().unwrap()
+		.get_property_value("display").unwrap();
+	let about_display = window.get_computed_style(&about).unwrap().unwrap()
+		.get_property_value("display").unwrap();
+
+	assert_ne!(home_display, "none");
+	assert_eq!(about_display, "none");
+}
+
+// Setting hash before init selects the correct route
+#[wasm_bindgen_test]
+fn route_initial_hash() {
+	// Set hash BEFORE test_setup so the router picks it up on init
+	let w = web_sys::window().unwrap();
+	w.location().set_hash("about").unwrap();
+
+	test_setup! {
+		/home {
+			text: "Home";
+		}
+		/about {
+			text: "About";
+		}
+	}
+	let home = root.children().item(0).unwrap().dyn_into::<HtmlElement>().unwrap();
+	let about = root.children().item(1).unwrap().dyn_into::<HtmlElement>().unwrap();
+
+	// About should be visible, home hidden
+	let home_display = home.style().get_property_value("display").unwrap();
+	let about_display = about.style().get_property_value("display").unwrap();
+	assert_eq!(home_display, "none");
+	assert_ne!(about_display, "none");
+
+	// Clean up
+	w.location().set_hash("").unwrap();
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod routing;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Introduces `/name { }` route block syntax for SPA-style hash-based routing
- First route is visible by default; others hidden with `display:none`
- A `hashchange` event listener toggles route visibility at runtime based on URL hash
- Spans the full compiler pipeline: parser → analyzer → renderer → HTML codegen → Wasm codegen
- Fixes a bug where `document()` early-returned when `compiled_element` was empty, skipping router generation for purely static route content

## Test plan
- [x] `route_creates_elements` — verifies route blocks render as elements with `data-route` attributes
- [x] `route_default_visibility` — verifies first route visible, others hidden by default
- [x] `route_initial_hash` — verifies setting URL hash before init selects the correct route
- [x] All 46 tests pass (43 existing + 3 new routing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)