### PR TITLE
Improve compiler error messages — replace panics with diagnostics

### DIFF
--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -17,8 +17,8 @@ pub struct Page {
 
 #[derive(Default)]
 pub struct Semantics {
-	pub errors: Vec<&'static str>,
-	pub warnings: Vec<&'static str>,
+	pub errors: Vec<String>,
+	pub warnings: Vec<String>,
 	pub styles: CssRules,
 
 	pub pages: Vec<Page>,

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -29,22 +29,23 @@ fn is_css_property(name: &str) -> bool {
 }
 
 impl Property {
-	pub fn new(property: String) -> Self {
+	pub fn new(property: String) -> Result<Self, String> {
 		if is_css_property(&property) {
-			Self::Css(property)
+			Ok(Self::Css(property))
 		} else {
 			match property.as_str() {
-				"title" => Self::Page(PageProperty::Title),
+				"title" => Ok(Self::Page(PageProperty::Title)),
 
-				property => Self::Cui(match property {
-					"text" => CuiProperty::Text,
-					"link" => CuiProperty::Link,
-					"tooltip" => CuiProperty::Tooltip,
-					"image" => CuiProperty::Image,
-					"apply" => CuiProperty::Apply,
+				"text" => Ok(Self::Cui(CuiProperty::Text)),
+				"link" => Ok(Self::Cui(CuiProperty::Link)),
+				"tooltip" => Ok(Self::Cui(CuiProperty::Tooltip)),
+				"image" => Ok(Self::Cui(CuiProperty::Image)),
+				"apply" => Ok(Self::Cui(CuiProperty::Apply)),
 
-					property => panic!(" property not recognized: {}", property),
-				}),
+				_ => Err(format!(
+					"property '{}' is not a recognized CSS or CUI property",
+					property
+				)),
 			}
 		}
 	}

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -108,11 +108,17 @@ impl Semantics {
 				group_id
 			);
 			let value = self.create_semantic_value(&value);
-			let property = Property::new(property);
-			if let Property::Css(_) = property {
-				self.groups[group_id].has_css_properties = true;
+			match Property::new(property) {
+				Ok(property) => {
+					if let Property::Css(_) = property {
+						self.groups[group_id].has_css_properties = true;
+					}
+					self.groups[group_id].properties.insert(property, value);
+				}
+				Err(error) => {
+					self.errors.push(error);
+				}
 			}
-			self.groups[group_id].properties.insert(property, value);
 		}
 
 		for block in block.listeners {

--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -90,11 +90,11 @@ impl Semantics {
 					return quote! {};
 				}
 
-				let event = match &**self.groups[listener_id]
+				let event_name = self.groups[listener_id]
 					.name
 					.as_ref()
-					.expect("every listener should have an event id")
-				{
+					.expect("every listener should have an event name");
+				let event = match &**event_name {
 					"blur" => quote! { set_onblur },
 					"focus" => quote! { set_onfocus },
 					"click" => quote! { set_onclick },
@@ -102,7 +102,11 @@ impl Semantics {
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
-					_ => panic!("unknown event id"),
+					unknown => panic!(
+						"unknown event type '?{}'. Supported events: blur, focus, click, \
+						mouseover, mouseenter, mouseleave, mouseout",
+						unknown
+					),
 				};
 
 				let rules = self.provide_state(rules);

--- a/src/transform/compile/wasm/initialize/register.rs
+++ b/src/transform/compile/wasm/initialize/register.rs
@@ -56,14 +56,14 @@ impl Semantics {
 			}
 		});
 		let properties =
-			(self.groups[group_id].properties.iter()).map(|(property, value)| match property {
-				Property::Css(property) => quote! {
+			(self.groups[group_id].properties.iter()).filter_map(|(property, value)| match property {
+				Property::Css(property) => Some(quote! {
 					group.properties.insert(Property::Css(#property), Value::String(#value));
-				},
-				Property::Cui(property) => quote! {
+				}),
+				Property::Cui(property) => Some(quote! {
 					group.properties.insert(Property::#property, Value::String(#value));
-				},
-				_ => panic!("aaaAA"),
+				}),
+				Property::Page(_) => None, // Page properties don't get registered in runtime groups
 			});
 		quote! {
 			#( #elements )*

--- a/src/transform/render/cascade.rs
+++ b/src/transform/render/cascade.rs
@@ -21,7 +21,11 @@ impl Semantics {
 			target_id
 		);
 		if source_id == target_id {
-			panic!("the build process should never try to cascade a group into itself")
+			panic!(
+				"compiler bug: attempted to cascade group {} into itself. \
+				This indicates a cycle in the class/element relationship graph.",
+				source_id
+			)
 		}
 
 		if !virtual_ {
@@ -117,7 +121,12 @@ impl Semantics {
 			&& !self.groups[source_id].elements.is_empty()
 			&& !self.groups[target_id].elements.is_empty()
 		{
-			panic!("Source and target group specify different contents for the same element")
+			panic!(
+				"conflicting element children: group {} (source) and group {} (target) \
+				both define child elements in the same listener scope. \
+				Only one group in a cascade chain should define element children.",
+				source_id, target_id
+			)
 		}
 
 		for element_id in self.groups[source_id].elements.clone() {

--- a/src/transform/render/value.rs
+++ b/src/transform/render/value.rs
@@ -72,7 +72,12 @@ impl Semantics {
 						);
 					}
 				}
-				panic!("unable to render variable '{}' from ancestors", identifier)
+				panic!(
+						"undefined variable '${}'. Variables must be declared with 'let' in an \
+						ancestor scope before use. Searched {} ancestor group(s).",
+						identifier,
+						ancestors.len()
+					)
 			}
 			Value::Variable(..) => value, // already rendered, idempotent
 			value => value,
@@ -180,8 +185,13 @@ impl Semantics {
 			Value::Static(value) => value.clone(),
 			&Value::Variable(variable_id, None) => self.get_static(&self.variables[variable_id].0),
 			Value::Variable(_, Some(value)) => value.clone(),
-			Value::UnrenderedVariable(_) => {
-				panic!("cannot get static value of unrendered variable")
+			Value::UnrenderedVariable(ref name) => {
+				panic!(
+					"cannot get static value of unrendered variable '${}'. \
+					This is a compiler bug — the variable should have been resolved \
+					during the render phase before reaching codegen.",
+					name
+				)
 			}
 			Value::ClassRef(name) => StaticValue::String(format!(".{}", name)),
 		}


### PR DESCRIPTION
## Summary
- Unknown properties now produce `compile_error!` instead of panicking (uses the existing error collection system)
- Fixed 6 panic messages across the compiler to be informative and actionable
- Changed `Semantics.errors`/`warnings` from `Vec<&'static str>` to `Vec<String>` for dynamic messages
- `register.rs`: replaced "aaaAA" with graceful handling of Page properties
- `compiled.rs`: unknown events now name the event and list valid options

## Test plan
- [x] All 43 existing tests pass
- [x] No behavior changes for valid CUI code
- [x] Invalid properties now produce compile errors instead of proc-macro panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)