### PR TITLE
Implement tooltip and image property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let tooltip = self.properties.get(&Property::Cui(CuiProperty::Tooltip));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"title",
+				&*tooltip
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),
@@ -78,13 +85,20 @@ impl Group {
 			.map(|&child_id| groups[child_id].html(groups))
 			.collect::<String>();
 
+		let image_html = if let Some(value) = self.properties.get(&Property::Cui(CuiProperty::Image)) {
+			format!("<img src='{}'>", value)
+		} else {
+			"".into()
+		};
+
 		let contents = format!(
-			"{}{}",
+			"{}{}{}",
 			if let Some(value) = self.properties.get(&Property::Cui(CuiProperty::Text)) {
 				value.to_string()
 			} else {
 				"".into()
 			},
+			image_html,
 			children
 		);
 

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,30 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Tooltip)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(string) = #value {
+					element.set_attribute("title", string).unwrap();
+				}
+			});
+		}
+
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Image)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(src) = #value {
+					let img = document
+						.create_element("img")
+						.unwrap()
+						.dyn_into::<HtmlElement>()
+						.unwrap();
+					img.set_attribute("src", src).unwrap();
+					element.append_child(&img).unwrap();
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -115,12 +115,28 @@ impl Semantics {
 			// }
 
 			fn render_property(element: &HtmlElement, property: &Property, value: Value) {
+				let window = web_sys::window().unwrap();
+				let document = window.document().unwrap();
 				match property {
 					Property::Css(property) => element.css(property, value),
 					Property::Link => (),
 					Property::Text => element.text(value),
-					Property::Tooltip => (),
-					Property::Image => (),
+					Property::Tooltip => {
+						if let Value::String(string) = value {
+							element.set_attribute("title", string).unwrap();
+						}
+					},
+					Property::Image => {
+						if let Value::String(src) = value {
+							let img = document
+								.create_element("img")
+								.unwrap()
+								.dyn_into::<HtmlElement>()
+								.unwrap();
+							img.set_attribute("src", src).unwrap();
+							element.append_child(&img).unwrap();
+						}
+					},
 					Property::Apply => (),
 				}
 			}

--- a/tests/properties/image.rs
+++ b/tests/properties/image.rs
@@ -1,0 +1,32 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+// image: should create an <img> element with src attribute
+#[wasm_bindgen_test]
+fn image_creates_img() {
+	test_setup! {
+		image: "photo.png";
+	}
+	let img = root.query_selector("img").unwrap().unwrap();
+	assert_eq!(img.get_attribute("src").unwrap(), "photo.png");
+}
+
+// image with text should have both
+#[wasm_bindgen_test]
+fn image_with_text() {
+	test_setup! {
+		text: "Caption";
+		image: "photo.png";
+	}
+	// Text should be present
+	assert!(root.inner_html().contains("Caption"));
+	// Img element should exist with correct src
+	let img = root.query_selector("img").unwrap().unwrap();
+	assert_eq!(img.get_attribute("src").unwrap(), "photo.png");
+}

--- a/tests/properties/tooltip.rs
+++ b/tests/properties/tooltip.rs
@@ -1,0 +1,51 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+// tooltip: should set the title attribute on the element
+#[wasm_bindgen_test]
+fn tooltip_sets_title() {
+	test_setup! {
+		text: "hover me";
+		tooltip: "This is a tooltip";
+	}
+	assert_eq!(
+		root.get_attribute("title").unwrap(),
+		"This is a tooltip"
+	);
+}
+
+// tooltip in a class should cascade to matching elements
+#[wasm_bindgen_test]
+fn tooltip_from_class() {
+	test_setup! {
+		.info {
+			tooltip: "Info tooltip";
+		}
+		info {
+			text: "hover me";
+		}
+	}
+	let el = root.children().item(0).unwrap().dyn_into::<HtmlElement>().unwrap();
+	assert_eq!(el.get_attribute("title").unwrap(), "Info tooltip");
+}
+
+// tooltip set dynamically via click handler
+#[wasm_bindgen_test]
+fn tooltip_dynamic() {
+	test_setup! {
+		text: "click me";
+		tooltip: "before click";
+		?click {
+			tooltip: "after click";
+		}
+	}
+	assert_eq!(root.get_attribute("title").unwrap(), "before click");
+	root.click();
+	assert_eq!(root.get_attribute("title").unwrap(), "after click");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,8 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod image;
 	mod text;
 	mod title;
+	mod tooltip;
 }


### PR DESCRIPTION
## Summary
- `tooltip:` now sets the HTML `title` attribute on elements (hover text)
- `image:` now creates an `<img>` child element with `src` attribute
- Both properties were previously parsed but returned `()` in codegen
- Works in static HTML output, Wasm initialization, and dynamic (listener) contexts

## Test plan
- [x] `tooltip_sets_title` — `tooltip: "text"` sets title attribute
- [x] `tooltip_from_class` — tooltip cascades from class to element
- [x] `tooltip_dynamic` — tooltip updated via click handler
- [x] `image_creates_img` — `image: "photo.png"` creates `<img src="photo.png">`
- [x] `image_with_text` — image and text coexist on same element
- [x] All 43 existing tests still pass (48 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)