### PR TITLE
Clean up dead code, fix id_gen race condition, zero warnings

### DIFF
--- a/src/misc/id_gen.rs
+++ b/src/misc/id_gen.rs
@@ -11,8 +11,7 @@ static SYMBOLS_2: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 
 
 pub fn generate_class_id() -> String {
 	let mut id = String::from("");
-	let mut n = CLASS_COUNTER.load(Ordering::Relaxed);
-	CLASS_COUNTER.swap(n + 1, Ordering::Relaxed);
+	let mut n = CLASS_COUNTER.fetch_add(1, Ordering::SeqCst);
 
 	loop {
 		let symbol_pool = if id.is_empty() {
@@ -35,11 +34,9 @@ pub fn generate_class_id() -> String {
 }
 
 pub fn generate_mutable_id() -> usize {
-	let n = MUTABLE_COUNTER.load(Ordering::Relaxed);
-	MUTABLE_COUNTER.swap(n + 1, Ordering::Relaxed);
-	n
+	MUTABLE_COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
 pub fn reset_mutable_counter() {
-	MUTABLE_COUNTER.swap(0, Ordering::Relaxed);
+	MUTABLE_COUNTER.store(0, Ordering::SeqCst);
 }

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,10 +188,6 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
-		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
-		// 	effects.push(quote! {});
-		// }
-
 		for (property, value) in properties {
 			if let Property::Css(property) = property {
 				let value = self.compiled_dynamic_value(value);

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -117,13 +117,9 @@ impl Semantics {
 		let mut mutables = vec![quote! {}; self.mutable_count];
 		for (value, mutable_id) in &self.variables {
 			if let &Some(mutable_id) = mutable_id {
-				// if !mutables[mutable_id].is_empty() {
-				// 	panic!("multiple default values for same mutable")
-				// }
 				let type_ = match self.get_static(value) {
 					StaticValue::Number(_) => quote! { Number },
 					StaticValue::String(_) => quote! { String },
-					// StaticValue::Color(_, _, _, _) => quote! { String },
 				};
 				mutables[mutable_id] = quote! {
 					Value::#type_(#value)

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -23,7 +23,6 @@ impl Semantics {
 						.unwrap();
 					child.set_class_name(&element.class_names.join(" "));
 					parent.append_child(child).unwrap();
-					// register_variables(element);
 					render_classes(element, classes);
 					render_listeners(element, child);
 					render_properties(element, child);
@@ -39,7 +38,6 @@ impl Semantics {
 					let elements = document.get_elements_by_class_name(class.selector);
 					for i in 0..elements.length() {
 						let element = &mut elements.item(i).unwrap().dyn_into::<HtmlElement>().unwrap();
-						// register_variables(class);
 						render_elements(class, element, classes);
 						render_listeners(class, element);
 						render_properties(class, element);
@@ -57,9 +55,6 @@ impl Semantics {
 							e.stop_propagation();
 							CLASSES.with(|classes| {
 								let mut classes = classes.borrow_mut();
-
-								// TODO: does this make sense if something else changes the group?
-								// render_variables(&group);
 								render_classes(&group, &mut classes);
 								render_elements(&group, &mut element, &mut classes);
 								render_listeners(&group, &mut element);
@@ -81,38 +76,6 @@ impl Semantics {
 					render_property(element, property, value.clone());
 				}
 			}
-
-			// fn render_variables(group: &Group) {
-			// 	STATE.with(|state| {
-			// 		let mut state = state.borrow_mut();
-			// 		let window = web_sys::window().unwrap();
-			// 		let document = &window.document().unwrap();
-			// 		for (variable_id, value) in &group.variables {
-			// 			render_variable(variable_id, value);
-			// 		}
-			// 	})
-			// }
-
-			// fn render_variable(id: usize, value: Value) {
-			// 	state[*id] = value;
-			// 	for (target, property, value) in effects[*id] {
-			// 		match target {
-			// 			EffectTarget::Element(element) => render_property(element, property, value),
-			// 			EffectTarget::Class(class) => {
-			// 				let elements = document.get_elements_by_class_name(class);
-			// 				for i in 0..elements.length() {
-			// 					let element = &mut elements
-			// 						.item(i)
-			// 						.unwrap()
-			// 						.dyn_into::<HtmlElement>()
-			// 						.unwrap();
-			// 					render_property(element, property, value);
-			// 				}
-			// 			}
-			// 			EffectTarget::Variable(variable_id) => render_variable(variable_id, value),
-			// 		}
-			// 	}
-			// }
 
 			fn render_property(element: &HtmlElement, property: &Property, value: Value) {
 				match property {

--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -8,9 +8,6 @@ pub trait Peek {
 	fn peek_variable(&self) -> bool;
 	fn peek_declaration(&self) -> bool;
 	fn peek_assignment(&self) -> bool;
-
-	// keywords
-	fn peek_use(&self) -> bool;
 }
 
 impl Peek for ParseStream<'_> {
@@ -36,9 +33,5 @@ impl Peek for ParseStream<'_> {
 	}
 	fn peek_variable(&self) -> bool {
 		self.peek(Token![$]) && self.peek2(Ident::peek_any)
-	}
-
-	fn peek_use(&self) -> bool {
-		self.peek(Token![use]) && self.peek2(Token![:])
 	}
 }


### PR DESCRIPTION
## Summary
- Removed unused `peek_use` method that caused a compiler warning every build
- Removed 30+ lines of commented-out `render_variables`/`render_variable` code
- Removed stale TODO comments and dead Color variant code
- Fixed atomic counter race condition in `id_gen.rs`: replaced `load` + `swap` with `fetch_add(SeqCst)`
- Net -55 lines, zero compiler warnings

## Test plan
- [x] All 43 tests pass
- [x] Zero compiler warnings (was 1)
- [x] No behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)