### PR TITLE
Generate valid HTML5 with DOCTYPE, charset, and viewport meta

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -16,9 +16,11 @@ impl Semantics {
 		// TODO: make this cleaner with a lightweight html!() macro
 
 		let html = format!(
-			"<html>{}{}</html>",
+			"<!DOCTYPE html><html lang='en'>{}{}</html>",
 			format_args!(
-				"<head>{}{}</head>",
+				"<head>{}{}{}{}</head>",
+				"<meta charset='UTF-8'>",
+				"<meta name='viewport' content='width=device-width, initial-scale=1.0'>",
 				format_args!("<title>{}</title>", root.title),
 				format_args!("<style>{}</style>", styles)
 			),


### PR DESCRIPTION
## Summary
- Added `<!DOCTYPE html>` declaration to generated HTML
- Added `lang='en'` attribute on `<html>` element
- Added `<meta charset='UTF-8'>` in `<head>`
- Added `<meta name='viewport' content='width=device-width, initial-scale=1.0'>` for mobile responsiveness
- CUI pages now generate valid HTML5 out of the box

## Test plan
- [x] All 43 tests pass (HTML5 changes only affect static output, not test infrastructure)
- [x] No behavior changes for existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)