### PR TITLE
Add box-sizing: border-box default CSS reset

### DIFF
--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -6,6 +6,17 @@ use crate::data::{
 impl Document {
 	pub fn analyze(self) -> Semantics {
 		let mut semantics = Semantics::default();
+		// Modern CSS defaults: border-box sizing for all elements
+		semantics.styles.insert(
+			"*, *::before, *::after".to_string(),
+			[(
+				"box-sizing".to_string(),
+				Value::Static(StaticValue::String("border-box".to_string())),
+			)]
+			.iter()
+			.cloned()
+			.collect(),
+		);
 		semantics.styles.insert(
 			"body".to_string(),
 			[(


### PR DESCRIPTION
## Summary
- Adds `*, *::before, *::after { box-sizing: border-box }` as default CSS
- This is modern CSS best practice — prevents padding/border from expanding elements beyond set dimensions
- Joins existing defaults: `body { margin: 0 }` and `a { display: block }`

## Test plan
- [x] All 43 tests pass
- [x] No behavior changes for existing tests (box-sizing only matters when width+padding are both set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)