### PR TITLE
Add value concatenation in properties

### DIFF
--- a/src/data/ast.rs
+++ b/src/data/ast.rs
@@ -31,6 +31,7 @@ pub enum Value {
 	String(String),
 	Variable(Variable),
 	ClassRef(String),
+	Concat(Vec<Value>),
 }
 
 pub struct Property {

--- a/src/data/semantics/value.rs
+++ b/src/data/semantics/value.rs
@@ -6,6 +6,25 @@ pub enum Value {
 	Variable(usize, Option<StaticValue>),
 	UnrenderedVariable(String),
 	ClassRef(String),
+	Concat(Vec<Value>),
+}
+
+impl Value {
+	/// If all parts of a Concat are static, collapse into a single Static string value.
+	pub fn try_collapse(self) -> Self {
+		match self {
+			Value::Concat(parts) => {
+				let parts: Vec<Value> = parts.into_iter().map(|p| p.try_collapse()).collect();
+				if parts.iter().all(|p| matches!(p, Value::Static(_))) {
+					let s: String = parts.iter().map(|p| p.to_string()).collect();
+					Value::Static(StaticValue::String(s))
+				} else {
+					Value::Concat(parts)
+				}
+			}
+			other => other,
+		}
+	}
 }
 
 #[derive(Clone, Debug)]

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -132,6 +132,9 @@ impl Semantics {
 			AstValue::Number(value) => Value::Static(StaticValue::Number(*value)),
 			AstValue::String(value) => Value::Static(StaticValue::String(value.clone())),
 			AstValue::ClassRef(name) => Value::ClassRef(name.clone()),
+			AstValue::Concat(values) => {
+				Value::Concat(values.iter().map(|v| self.create_semantic_value(v)).collect())
+			}
 		}
 	}
 }

--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -94,7 +94,7 @@ impl Parse for Property {
 			property.push_str(&next.to_string());
 		}
 		input.parse::<Token![:]>()?;
-		let value = input.parse()?;
+		let value = parse_value_expr(input)?;
 		input.parse::<Token![;]>()?;
 		Ok(Self { property, value })
 	}
@@ -104,10 +104,24 @@ impl Parse for Assignment {
 	fn parse(input: ParseStream) -> Result<Self, syn::Error> {
 		let variable = input.parse()?;
 		input.parse::<Token![:]>()?;
-		let value = input.parse()?;
+		let value = parse_value_expr(input)?;
 		input.parse::<Token![;]>()?;
 		Ok(Self { variable, value })
 	}
+}
+
+/// Parse a value expression: a single value or multiple values concatenated.
+/// Multiple values before a `;` are wrapped in `Value::Concat`.
+fn parse_value_expr(input: ParseStream) -> Result<Value, syn::Error> {
+	let first: Value = input.parse()?;
+	if input.peek(Token![;]) {
+		return Ok(first);
+	}
+	let mut values = vec![first];
+	while !input.peek(Token![;]) {
+		values.push(input.parse()?);
+	}
+	Ok(Value::Concat(values))
 }
 
 impl Parse for Value {

--- a/src/transform/render/value.rs
+++ b/src/transform/render/value.rs
@@ -11,17 +11,19 @@ use {
 
 impl fmt::Display for Value {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(
-			f,
-			"{}",
-			match self {
-				Value::Static(value) => value.to_string(),
-				Value::Variable(_, Some(value)) => value.to_string(),
-				Value::Variable(variable_id, None) => format!("<{}>", variable_id),
-				Value::UnrenderedVariable(_) => "@variable".to_string(),
-				Value::ClassRef(name) => format!(".{}", name),
+		match self {
+			Value::Static(value) => write!(f, "{}", value),
+			Value::Variable(_, Some(value)) => write!(f, "{}", value),
+			Value::Variable(variable_id, None) => write!(f, "<{}>", variable_id),
+			Value::UnrenderedVariable(_) => write!(f, "@variable"),
+			Value::ClassRef(name) => write!(f, ".{}", name),
+			Value::Concat(parts) => {
+				for part in parts {
+					write!(f, "{}", part)?;
+				}
+				Ok(())
 			}
-		)
+		}
 	}
 }
 
@@ -29,6 +31,12 @@ impl ToTokens for Value {
 	fn to_tokens(&self, tokens: &mut TokenStream) {
 		match self {
 			Value::ClassRef(_) => {}, // ClassRef is not a runtime value
+			Value::Concat(parts) => {
+				// Static concatenation was already collapsed in render_value.
+				// If we still have a Concat here, all parts should be static after rendering.
+				let s: String = parts.iter().map(|p| p.to_string()).collect();
+				s.to_tokens(tokens);
+			}
 			_ => self.to_string().to_tokens(tokens),
 		}
 	}
@@ -73,6 +81,14 @@ impl Semantics {
 					}
 				}
 				panic!("unable to render variable '{}' from ancestors", identifier)
+			}
+			Value::Concat(parts) => {
+				let rendered: Vec<Value> = parts
+					.into_iter()
+					.map(|part| self.render_value(part, ancestors))
+					.collect();
+				// Collapse to single static string if all parts resolved to static values
+				Value::Concat(rendered).try_collapse()
 			}
 			Value::Variable(..) => value, // already rendered, idempotent
 			value => value,
@@ -184,6 +200,10 @@ impl Semantics {
 				panic!("cannot get static value of unrendered variable")
 			}
 			Value::ClassRef(name) => StaticValue::String(format!(".{}", name)),
+			Value::Concat(parts) => {
+				let s: String = parts.iter().map(|p| self.get_static(p).to_string()).collect();
+				StaticValue::String(s)
+			}
 		}
 	}
 }

--- a/tests/properties/concatenation.rs
+++ b/tests/properties/concatenation.rs
@@ -1,0 +1,46 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn string_literals() {
+	test_setup! {
+		text: "Hello, " "World" "!";
+	}
+	assert_eq!(root.inner_html(), "Hello, World!");
+}
+
+#[wasm_bindgen_test]
+fn with_variable() {
+	test_setup! {
+		let $name: "World";
+		text: "Hello, " $name "!";
+	}
+	assert_eq!(root.inner_html(), "Hello, World!");
+}
+
+#[wasm_bindgen_test]
+fn variable_only_unchanged() {
+	test_setup! {
+		let $greeting: "hi";
+		text: $greeting;
+	}
+	assert_eq!(root.inner_html(), "hi");
+}
+
+#[wasm_bindgen_test]
+fn in_child_element() {
+	test_setup! {
+		let $color: "red";
+		item {
+			text: "Color: " $color;
+		}
+	}
+	let el = root.first_element_child().expect("should have child");
+	assert_eq!(el.inner_html(), "Color: red");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod concatenation;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Multiple values in a property are concatenated: `text: "Hello, " $name "!";`
- Adds `Concat(Vec<Value>)` variant to both AST and semantic Value enums
- Parser collects values between `:` and `;`, wraps in `Concat` when multiple
- During rendering, all parts are resolved and collapsed to a single static string when possible
- Works with string literals, static variables, and combinations

## Test plan
- [x] `string_literals` — `text: "Hello, " "World" "!";` → `"Hello, World!"`
- [x] `with_variable` — `let $name: "World"; text: "Hello, " $name "!";` → `"Hello, World!"`
- [x] `variable_only_unchanged` — single variable values still work
- [x] `in_child_element` — concatenation works in nested elements
- [x] All 43 existing tests continue to pass (47 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)