### PR TITLE
Add 8 new event types

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -98,10 +98,18 @@ impl Semantics {
 					"blur" => quote! { set_onblur },
 					"focus" => quote! { set_onfocus },
 					"click" => quote! { set_onclick },
+					"dblclick" => quote! { set_ondblclick },
+					"mousedown" => quote! { set_onmousedown },
+					"mouseup" => quote! { set_onmouseup },
+					"mousemove" => quote! { set_onmousemove },
 					"mouseover" => quote! { set_onmouseover },
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
+					"keydown" => quote! { set_onkeydown },
+					"keyup" => quote! { set_onkeyup },
+					"scroll" => quote! { set_onscroll },
+					"contextmenu" => quote! { set_oncontextmenu },
 					_ => panic!("unknown event id"),
 				};
 

--- a/tests/misc/new_events.rs
+++ b/tests/misc/new_events.rs
@@ -1,0 +1,117 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+fn dispatch(element: &HtmlElement, event_name: &str) {
+	let event = Event::new(event_name).unwrap();
+	element.dispatch_event(&event).unwrap();
+}
+
+#[wasm_bindgen_test]
+fn dblclick() {
+	test_setup! {
+		text: "waiting";
+		?dblclick {
+			text: "double clicked";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "dblclick");
+	assert_eq!(root.inner_html(), "double clicked");
+}
+
+#[wasm_bindgen_test]
+fn mousedown() {
+	test_setup! {
+		text: "waiting";
+		?mousedown {
+			text: "mouse down";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "mousedown");
+	assert_eq!(root.inner_html(), "mouse down");
+}
+
+#[wasm_bindgen_test]
+fn mouseup() {
+	test_setup! {
+		text: "waiting";
+		?mouseup {
+			text: "mouse up";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "mouseup");
+	assert_eq!(root.inner_html(), "mouse up");
+}
+
+#[wasm_bindgen_test]
+fn mousemove() {
+	test_setup! {
+		text: "waiting";
+		?mousemove {
+			text: "mouse moved";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "mousemove");
+	assert_eq!(root.inner_html(), "mouse moved");
+}
+
+#[wasm_bindgen_test]
+fn keydown() {
+	test_setup! {
+		text: "waiting";
+		?keydown {
+			text: "key pressed";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "keydown");
+	assert_eq!(root.inner_html(), "key pressed");
+}
+
+#[wasm_bindgen_test]
+fn keyup() {
+	test_setup! {
+		text: "waiting";
+		?keyup {
+			text: "key released";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "keyup");
+	assert_eq!(root.inner_html(), "key released");
+}
+
+#[wasm_bindgen_test]
+fn scroll() {
+	test_setup! {
+		text: "waiting";
+		?scroll {
+			text: "scrolled";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "scroll");
+	assert_eq!(root.inner_html(), "scrolled");
+}
+
+#[wasm_bindgen_test]
+fn contextmenu() {
+	test_setup! {
+		text: "waiting";
+		?contextmenu {
+			text: "right clicked";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	dispatch(&root, "contextmenu");
+	assert_eq!(root.inner_html(), "right clicked");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod new_events;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds `dblclick`, `mousedown`, `mouseup`, `mousemove`, `keydown`, `keyup`, `scroll`, and `contextmenu` event listener types
- Extends supported events from 7 to 15 — all map to their standard `set_on*` web_sys handlers
- 8 new tests verify each event fires correctly via `dispatch_event`

## Test plan
- [x] All 51 tests pass (43 existing + 8 new)
- [x] Each new event type verified via `Event::new()` + `dispatch_event()`
- [x] No changes to existing tests or behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)