### PR TITLE
Implement link: dynamic codegen

### DIFF
--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,9 +188,10 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
-		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
-		// 	effects.push(quote! {});
-		// }
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Link)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! { element.link(#value); });
+		}
 
 		for (property, value) in properties {
 			if let Property::Css(property) = property {

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -72,6 +72,7 @@ fn header() -> TokenStream {
 
 		trait Std {
 			fn text(&self, value: Value);
+			fn link(&self, value: Value);
 			fn css(&self, property: &'static str, value: Value);
 		}
 
@@ -85,6 +86,12 @@ fn header() -> TokenStream {
 				}
 				if let Value::String(string) = value {
 					self.prepend_with_str_1(string).unwrap();
+				}
+			}
+
+			fn link(&self, value: Value) {
+				if let Value::String(string) = value {
+					self.set_attribute("href", string).unwrap();
 				}
 			}
 

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -117,7 +117,7 @@ impl Semantics {
 			fn render_property(element: &HtmlElement, property: &Property, value: Value) {
 				match property {
 					Property::Css(property) => element.css(property, value),
-					Property::Link => (),
+					Property::Link => element.link(value),
 					Property::Text => element.text(value),
 					Property::Tooltip => (),
 					Property::Image => (),

--- a/tests/properties/link.rs
+++ b/tests/properties/link.rs
@@ -1,0 +1,62 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn static_link() {
+	test_setup! {
+		item {
+			link: "#page";
+			text: "go to page";
+		}
+	}
+	let element = root
+		.first_element_child()
+		.expect("should have child element");
+	assert_eq!(element.tag_name(), "A");
+	assert_eq!(element.get_attribute("href").unwrap(), "#page");
+}
+
+#[wasm_bindgen_test]
+fn link_updates_dynamically() {
+	test_setup! {
+		item {
+			link: "#first";
+			text: "click me";
+			?click {
+				link: "#second";
+			}
+		}
+	}
+	let element = root
+		.first_element_child()
+		.expect("should have child element")
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.get_attribute("href").unwrap(), "#first");
+	let event = Event::new("click").unwrap();
+	element.dispatch_event(&event).unwrap();
+	assert_eq!(element.get_attribute("href").unwrap(), "#second");
+}
+
+#[wasm_bindgen_test]
+fn link_from_class() {
+	test_setup! {
+		.item {
+			link: "#class-link";
+		}
+		item {
+			text: "linked from class";
+		}
+	}
+	let element = root
+		.first_element_child()
+		.expect("should have child element");
+	assert_eq!(element.tag_name(), "A");
+	assert_eq!(element.get_attribute("href").unwrap(), "#class-link");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod link;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Implements the `link:` property for dynamic contexts (listeners)
- Adds `link()` method to Std trait that sets `href` attribute via `set_attribute`
- Previously `link:` only worked statically (tag → `<a>`, href in HTML); now href updates at runtime
- 3 new tests: static link, dynamic update in listener, class cascading

## Test plan
- [x] All 46 tests pass (43 existing + 3 new)
- [x] Static link creates `<a>` tag with correct href
- [x] Dynamic link update changes href attribute on click
- [x] Link property cascades from class to element

🤖 Generated with [Claude Code](https://claude.com/claude-code)