### PR TITLE
Emit compile_error for unknown properties

### DIFF
--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -17,8 +17,8 @@ pub struct Page {
 
 #[derive(Default)]
 pub struct Semantics {
-	pub errors: Vec<&'static str>,
-	pub warnings: Vec<&'static str>,
+	pub errors: Vec<String>,
+	pub warnings: Vec<String>,
 	pub styles: CssRules,
 
 	pub pages: Vec<Page>,

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -29,22 +29,23 @@ fn is_css_property(name: &str) -> bool {
 }
 
 impl Property {
-	pub fn new(property: String) -> Self {
+	pub fn new(property: String) -> Result<Self, String> {
 		if is_css_property(&property) {
-			Self::Css(property)
+			Ok(Self::Css(property))
 		} else {
 			match property.as_str() {
-				"title" => Self::Page(PageProperty::Title),
+				"title" => Ok(Self::Page(PageProperty::Title)),
 
-				property => Self::Cui(match property {
-					"text" => CuiProperty::Text,
-					"link" => CuiProperty::Link,
-					"tooltip" => CuiProperty::Tooltip,
-					"image" => CuiProperty::Image,
-					"apply" => CuiProperty::Apply,
+				"text" => Ok(Self::Cui(CuiProperty::Text)),
+				"link" => Ok(Self::Cui(CuiProperty::Link)),
+				"tooltip" => Ok(Self::Cui(CuiProperty::Tooltip)),
+				"image" => Ok(Self::Cui(CuiProperty::Image)),
+				"apply" => Ok(Self::Cui(CuiProperty::Apply)),
 
-					property => panic!(" property not recognized: {}", property),
-				}),
+				_ => Err(format!(
+					"Unknown property '{}'. Not a recognized CSS or CUI property.",
+					property
+				)),
 			}
 		}
 	}

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -108,11 +108,17 @@ impl Semantics {
 				group_id
 			);
 			let value = self.create_semantic_value(&value);
-			let property = Property::new(property);
-			if let Property::Css(_) = property {
-				self.groups[group_id].has_css_properties = true;
+			match Property::new(property) {
+				Ok(property) => {
+					if let Property::Css(_) = property {
+						self.groups[group_id].has_css_properties = true;
+					}
+					self.groups[group_id].properties.insert(property, value);
+				}
+				Err(error) => {
+					self.errors.push(error);
+				}
 			}
-			self.groups[group_id].properties.insert(property, value);
 		}
 
 		for block in block.listeners {

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -176,19 +176,19 @@ impl Semantics {
 
 		log::debug!("Generated document");
 
-		if document.is_empty() {
-			return quote! {};
-		}
-
-		let document = self.provide_state(document);
-
 		let core = if !self.errors.is_empty() {
 			quote! {
 				#( #errors )*
 			}
+		} else if document.is_empty() {
+			return quote! {
+				#( #warnings )*
+			};
 		} else if full {
+			let document = self.provide_state(document);
 			self.full(document)
 		} else {
+			let document = self.provide_state(document);
 			document
 		};
 


### PR DESCRIPTION
## Summary
- Changed `Property::new` from panicking on unknown properties to returning `Result<Self, String>` with a descriptive error message
- Errors are collected in `Semantics::errors` during the analysis phase and emitted as `compile_error!` diagnostics
- Fixed a bug in `wasm()` where an early return on empty document silently swallowed all error diagnostics

## Test plan
- [x] All 43 existing tests pass
- [x] Verified `compile_error!("Unknown property 'foobar'...")` is emitted for unknown property names
- [x] Verified the error message includes the property name for easy debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)