### PR TITLE
Add id: property for HTML id attributes

### DIFF
--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -15,6 +15,7 @@ pub enum CuiProperty {
 	Tooltip,
 	Image,
 	Apply,
+	Id,
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Id => quote! { Id },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -42,6 +42,7 @@ impl Property {
 					"tooltip" => CuiProperty::Tooltip,
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
+					"id" => CuiProperty::Id,
 
 					property => panic!(" property not recognized: {}", property),
 				}),
@@ -62,6 +63,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Id => quote! { Id },
 			}
 		} else {
 			quote! {}

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let id = self.properties.get(&Property::Cui(CuiProperty::Id));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"id",
+				&*id
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Id,
 		}
 
 		#[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -122,6 +122,11 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Id => {
+						if let Value::String(s) = value {
+							element.set_id(s);
+						}
+					},
 				}
 			}
 		}

--- a/tests/properties/id.rs
+++ b/tests/properties/id.rs
@@ -1,0 +1,44 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn id_on_element() {
+	test_setup! {
+		child {
+			id: "my-element";
+			text: "Hello";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.id(), "my-element");
+	assert_eq!(child.inner_html(), "Hello");
+}
+
+#[wasm_bindgen_test]
+fn id_on_root() {
+	test_setup! {
+		id: "root-id";
+		text: "Root";
+	}
+	assert_eq!(root.id(), "root-id");
+}
+
+#[wasm_bindgen_test]
+fn id_from_class() {
+	test_setup! {
+		.labeled {
+			id: "from-class";
+		}
+		labeled {
+			text: "Labeled";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.id(), "from-class");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod id;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- New `id:` CUI property sets the HTML `id` attribute on elements
- Works in static HTML output and at runtime (dynamic element creation in listeners)
- Supports class cascading (`.labeled { id: "my-id"; }`)

## Test plan
- [x] `id_on_element` — child element gets `id="my-element"` attribute
- [x] `id_on_root` — root element gets id attribute
- [x] `id_from_class` — id cascades from class definition to element
- [x] All 46 tests pass (43 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)