### PR TITLE
Support CSS custom properties (--var-name syntax)

### DIFF
--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -30,7 +30,7 @@ fn is_css_property(name: &str) -> bool {
 
 impl Property {
 	pub fn new(property: String) -> Self {
-		if is_css_property(&property) {
+		if is_css_property(&property) || property.starts_with("--") {
 			Self::Css(property)
 		} else {
 			match property.as_str() {

--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -85,8 +85,17 @@ impl Parse for Block {
 
 impl Parse for Property {
 	fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-		// Parse hyphenated property names like font-family, max-width, etc.
-		let mut property = input.parse::<Ident>()?.to_string();
+		// Parse property names, including:
+		// - Simple: color, text, link
+		// - Hyphenated: font-family, max-width
+		// - CSS custom properties: --my-color, --theme-bg
+		let mut property = if input.peek(Token![-]) && input.peek2(Token![-]) {
+			input.parse::<Token![-]>()?;
+			input.parse::<Token![-]>()?;
+			format!("--{}", input.parse::<Ident>()?.to_string())
+		} else {
+			input.parse::<Ident>()?.to_string()
+		};
 		while input.peek(Token![-]) {
 			input.parse::<Token![-]>()?;
 			let next = input.parse::<Ident>()?;

--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -17,7 +17,9 @@ impl Peek for ParseStream<'_> {
 	fn peek_property(&self) -> bool {
 		// A property starts with an Ident but is NOT followed by a brace (that's an element block).
 		// Exclude `let` keyword (that's a variable declaration).
-		self.peek(Ident::peek_any) && !self.peek2(Brace) && !self.peek(Token![let])
+		// Also match CSS custom properties: --property-name
+		(self.peek(Ident::peek_any) && !self.peek2(Brace) && !self.peek(Token![let]))
+			|| (self.peek(Token![-]) && self.peek2(Token![-]))
 	}
 	fn peek_element_block(&self) -> bool {
 		self.peek(Ident::peek_any) && self.peek2(Brace) && !self.peek(Token![let])

--- a/tests/properties/css_custom.rs
+++ b/tests/properties/css_custom.rs
@@ -1,0 +1,53 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn custom_property_inline() {
+	test_setup! {
+		--my-color: "red";
+		color: "var(--my-color)";
+		text: "custom";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+}
+
+#[wasm_bindgen_test]
+fn custom_property_from_class() {
+	test_setup! {
+		.themed {
+			--theme-bg: "blue";
+		}
+		themed {
+			color: "var(--theme-bg)";
+			text: "themed";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	let style = window.get_computed_style(&child).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(0, 0, 255)");
+}
+
+#[wasm_bindgen_test]
+fn custom_property_dynamic() {
+	test_setup! {
+		let $color: "green";
+		--text-color: $color;
+		color: "var(--text-color)";
+		text: "dynamic";
+		?click {
+			$color: "purple";
+		}
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(0, 128, 0)");
+	root.click();
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(128, 0, 128)");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod css_custom;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- CSS custom properties (`--my-color: "red";`) now work in CUI syntax
- Parser extended to handle `--` prefix in property names
- Custom properties are recognized as CSS properties and go through the standard CSS pipeline
- Works with `var()` references, class cascading, and mutable CUI variables for reactive theming

## Test plan
- [x] `custom_property_inline` — define and reference custom property on same element via `var()`
- [x] `custom_property_from_class` — custom property cascades from class to element via CSS
- [x] `custom_property_dynamic` — custom property value changes reactively with mutable CUI variable
- [x] All 46 tests pass (43 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)