### PR TITLE
Remove unused peek_use to eliminate compiler warning

### DIFF
--- a/src/transform/parse/peek.rs
+++ b/src/transform/parse/peek.rs
@@ -8,9 +8,6 @@ pub trait Peek {
 	fn peek_variable(&self) -> bool;
 	fn peek_declaration(&self) -> bool;
 	fn peek_assignment(&self) -> bool;
-
-	// keywords
-	fn peek_use(&self) -> bool;
 }
 
 impl Peek for ParseStream<'_> {
@@ -36,9 +33,5 @@ impl Peek for ParseStream<'_> {
 	}
 	fn peek_variable(&self) -> bool {
 		self.peek(Token![$]) && self.peek2(Ident::peek_any)
-	}
-
-	fn peek_use(&self) -> bool {
-		self.peek(Token![use]) && self.peek2(Token![:])
 	}
 }


### PR DESCRIPTION
## Summary
- Removes the unused `peek_use` method from the `Peek` trait
- Eliminates the `method peek_use is never used` warning that appeared on every compilation

## Test plan
- [x] All 43 tests pass
- [x] Zero compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)