### PR TITLE
Implement tooltip: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let tooltip = self.properties.get(&Property::Cui(CuiProperty::Tooltip));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"title",
+				&*tooltip
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,15 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Tooltip)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value {
+					element.set_title(s);
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -119,7 +119,11 @@ impl Semantics {
 					Property::Css(property) => element.css(property, value),
 					Property::Link => (),
 					Property::Text => element.text(value),
-					Property::Tooltip => (),
+					Property::Tooltip => {
+						if let Value::String(s) = value {
+							element.set_title(s);
+						}
+					},
 					Property::Image => (),
 					Property::Apply => (),
 				}

--- a/tests/properties/tooltip.rs
+++ b/tests/properties/tooltip.rs
@@ -1,0 +1,58 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn tooltip_on_element() {
+	test_setup! {
+		item {
+			tooltip: "helper text";
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.title(), "helper text");
+}
+
+#[wasm_bindgen_test]
+fn tooltip_from_class() {
+	test_setup! {
+		.tip {
+			tooltip: "class tooltip";
+		}
+		tip {}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.title(), "class tooltip");
+}
+
+#[wasm_bindgen_test]
+fn tooltip_on_click() {
+	test_setup! {
+		item {
+			?click {
+				tooltip: "clicked!";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.title(), "");
+	element.click();
+	assert_eq!(element.title(), "clicked!");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,4 +20,5 @@ mod misc {
 mod properties {
 	mod text;
 	mod title;
+	mod tooltip;
 }


### PR DESCRIPTION
## Summary
- **tooltip:** CUI property now generates actual HTML/Wasm output instead of returning `()`
- Static HTML: renders as `title` attribute on the element
- Wasm runtime: `render_property` sets `element.set_title(s)` for dynamic updates
- Compiled dynamic: `compiled_dynamic_properties` generates tooltip code for listener contexts

## Test plan
- [x] `tooltip_on_element` — static tooltip renders in HTML, `element.title()` returns value
- [x] `tooltip_from_class` — tooltip cascades from class to element correctly
- [x] `tooltip_on_click` — tooltip set dynamically via listener works

All 46 tests pass (43 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)