### PR TITLE
Implement image: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,8 +58,16 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let image = self.properties.get(&Property::Cui(CuiProperty::Image));
+		let style = {
+			let mut s = self.properties.css();
+			if let Some(value) = image {
+				s.push_str(&format!("background-image:url(\"{}\");", value));
+			}
+			s
+		};
 		let attributes = [
-			("style", &*self.properties.css()),
+			("style", &*style),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,15 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Image)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value {
+					element.style().set_property("background-image", &format!("url('{}')", s)).unwrap();
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -120,7 +120,11 @@ impl Semantics {
 					Property::Link => (),
 					Property::Text => element.text(value),
 					Property::Tooltip => (),
-					Property::Image => (),
+					Property::Image => {
+						if let Value::String(s) = value {
+							element.style().set_property("background-image", &format!("url('{}')", s)).unwrap();
+						}
+					},
 					Property::Apply => (),
 				}
 			}

--- a/tests/properties/image.rs
+++ b/tests/properties/image.rs
@@ -1,0 +1,73 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn image_on_element() {
+	test_setup! {
+		item {
+			image: "photo.jpg";
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	let bg = element.style().get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("photo.jpg"),
+		"background-image should contain photo.jpg but was: {}",
+		bg
+	);
+}
+
+#[wasm_bindgen_test]
+fn image_from_class() {
+	test_setup! {
+		.banner {
+			image: "hero.png";
+		}
+		banner {}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	let bg = element.style().get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("hero.png"),
+		"background-image should contain hero.png but was: {}",
+		bg
+	);
+}
+
+#[wasm_bindgen_test]
+fn image_on_click() {
+	test_setup! {
+		item {
+			?click {
+				image: "clicked.jpg";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.style().get_property_value("background-image").unwrap(), "");
+	element.click();
+	let bg = element.style().get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("clicked.jpg"),
+		"background-image should contain clicked.jpg after click but was: {}",
+		bg
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod image;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- **image:** CUI property now generates actual HTML/CSS output instead of returning `()`
- Static HTML: renders as `background-image:url("...")` in inline style
- Wasm runtime: `render_property` sets `background-image` via style API for dynamic updates
- Compiled dynamic: `compiled_dynamic_properties` generates image code for listener contexts

## Test plan
- [x] `image_on_element` — static image renders in inline style, `background-image` contains URL
- [x] `image_from_class` — image cascades from class to element correctly
- [x] `image_on_click` — image set dynamically via listener works

All 46 tests pass (43 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)