### PR TITLE
Add ?dblclick event listener

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -102,6 +102,7 @@ impl Semantics {
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
+					"dblclick" => quote! { set_ondblclick },
 					_ => panic!("unknown event id"),
 				};
 

--- a/tests/misc/dblclick.rs
+++ b/tests/misc/dblclick.rs
@@ -1,0 +1,29 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn dblclick_event() {
+	test_setup! {
+		item {
+			text: "initial";
+			?dblclick {
+				text: "double clicked";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.inner_html(), "initial");
+	let event = Event::new("dblclick").unwrap();
+	element.dispatch_event(&event).unwrap();
+	assert_eq!(element.inner_html(), "double clicked");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,7 @@ mod data {
 mod misc {
 	mod basics;
 	mod complex;
+	mod dblclick;
 	mod events;
 }
 mod properties {


### PR DESCRIPTION
## Summary
- Add `dblclick` to the `compiled_listeners` event match in `compiled.rs`
- Maps to `set_ondblclick` on `HtmlElement`
- Enables `?dblclick { }` blocks for double-click handling in CUI

## Test plan
- [x] `dblclick_event` — text changes from "initial" to "double clicked" on dispatched dblclick event

All 44 tests pass (43 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)