### PR TITLE
Add 7 new event types: keyboard, form, and dblclick

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -102,6 +102,13 @@ impl Semantics {
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
+					"dblclick" => quote! { set_ondblclick },
+					"keydown" => quote! { set_onkeydown },
+					"keyup" => quote! { set_onkeyup },
+					"keypress" => quote! { set_onkeypress },
+					"input" => quote! { set_oninput },
+					"change" => quote! { set_onchange },
+					"submit" => quote! { set_onsubmit },
 					_ => panic!("unknown event id"),
 				};
 

--- a/tests/misc/keyboard_events.rs
+++ b/tests/misc/keyboard_events.rs
@@ -1,0 +1,92 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn keydown_event() {
+	test_setup! {
+		item {
+			text: "waiting";
+			?keydown {
+				text: "key pressed";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.inner_html(), "waiting");
+	let event = Event::new("keydown").unwrap();
+	element.dispatch_event(&event).unwrap();
+	assert_eq!(element.inner_html(), "key pressed");
+}
+
+#[wasm_bindgen_test]
+fn keyup_event() {
+	test_setup! {
+		item {
+			text: "waiting";
+			?keyup {
+				text: "key released";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.inner_html(), "waiting");
+	let event = Event::new("keyup").unwrap();
+	element.dispatch_event(&event).unwrap();
+	assert_eq!(element.inner_html(), "key released");
+}
+
+#[wasm_bindgen_test]
+fn input_event() {
+	test_setup! {
+		item {
+			text: "waiting";
+			?input {
+				text: "input received";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.inner_html(), "waiting");
+	let event = Event::new("input").unwrap();
+	element.dispatch_event(&event).unwrap();
+	assert_eq!(element.inner_html(), "input received");
+}
+
+#[wasm_bindgen_test]
+fn change_event() {
+	test_setup! {
+		item {
+			text: "waiting";
+			?change {
+				text: "value changed";
+			}
+		}
+	}
+	let element: HtmlElement = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.inner_html(), "waiting");
+	let event = Event::new("change").unwrap();
+	element.dispatch_event(&event).unwrap();
+	assert_eq!(element.inner_html(), "value changed");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod keyboard_events;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Expands compiled_listeners event match from 7 to 14 event types
- New events: `?dblclick`, `?keydown`, `?keyup`, `?keypress`, `?input`, `?change`, `?submit`
- Each maps to the corresponding `set_on<event>` method on HtmlElement

## Test plan
- [x] `keydown_event` — text changes on keydown dispatch
- [x] `keyup_event` — text changes on keyup dispatch
- [x] `input_event` — text changes on input dispatch
- [x] `change_event` — text changes on change dispatch

All 47 tests pass (43 existing + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)