### PR TITLE
Add ?init listener for initialization-time code

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -90,11 +90,19 @@ impl Semantics {
 					return quote! {};
 				}
 
-				let event = match &**self.groups[listener_id]
+				let name = &**self.groups[listener_id]
 					.name
 					.as_ref()
-					.expect("every listener should have an event id")
-				{
+					.expect("every listener should have an event id");
+
+				if name == "init" {
+					// ?init runs immediately during initialization, not on an event.
+					// No CLASSES.with needed — we're already inside it from document().
+					let rules = self.provide_state(rules);
+					return quote! { { #rules } };
+				}
+
+				let event = match name {
 					"blur" => quote! { set_onblur },
 					"focus" => quote! { set_onfocus },
 					"click" => quote! { set_onclick },

--- a/tests/misc/init_listener.rs
+++ b/tests/misc/init_listener.rs
@@ -1,0 +1,44 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn init_sets_text() {
+	test_setup! {
+		item {
+			text: "before";
+			?init {
+				text: "initialized";
+			}
+		}
+	}
+	let element = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	assert_eq!(element.inner_html(), "initialized");
+}
+
+#[wasm_bindgen_test]
+fn init_sets_css() {
+	test_setup! {
+		item {
+			?init {
+				color: "red";
+			}
+		}
+	}
+	let element = root
+		.first_element_child()
+		.unwrap()
+		.dyn_into::<HtmlElement>()
+		.unwrap();
+	let style = window.get_computed_style(&element).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod init_listener;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- New `?init { }` listener that runs immediately during Wasm initialization
- Unlike event listeners (click, keydown, etc.), ?init code executes inline without a closure
- Enables setting up initial element state that can't be expressed declaratively
- Example use case from SUGGESTIONS.md: resetting state when navigating between tutorial steps

## Implementation
- Detects "init" event name in `compiled_listeners` and emits rules inline
- No CLASSES.with wrapper needed since init runs inside the existing scope from `document()`
- `provide_state` handles STATE access for mutable variable support

## Test plan
- [x] `init_sets_text` — text is overwritten to "initialized" at load time
- [x] `init_sets_css` — CSS color is applied at load time

All 45 tests pass (43 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)