### PR TITLE
Add href: as alias for link: property

### DIFF
--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -38,7 +38,7 @@ impl Property {
 
 				property => Self::Cui(match property {
 					"text" => CuiProperty::Text,
-					"link" => CuiProperty::Link,
+					"link" | "href" => CuiProperty::Link,
 					"tooltip" => CuiProperty::Tooltip,
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,

--- a/tests/properties/href.rs
+++ b/tests/properties/href.rs
@@ -1,0 +1,45 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn href_creates_link() {
+	test_setup! {
+		item {
+			href: "https://example.com";
+			text: "click me";
+		}
+	}
+	let element = root
+		.first_element_child()
+		.expect("root should have a child element");
+	assert_eq!(element.tag_name(), "A");
+	assert_eq!(
+		element.get_attribute("href").unwrap(),
+		"https://example.com"
+	);
+	assert_eq!(element.inner_html(), "click me");
+}
+
+#[wasm_bindgen_test]
+fn href_from_class() {
+	test_setup! {
+		.nav {
+			href: "https://example.com";
+		}
+		nav {}
+	}
+	let element = root
+		.first_element_child()
+		.expect("root should have a child element");
+	assert_eq!(element.tag_name(), "A");
+	assert_eq!(
+		element.get_attribute("href").unwrap(),
+		"https://example.com"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod href;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- `href:` now maps to `CuiProperty::Link`, same as `link:`
- More intuitive syntax matching the HTML attribute name
- One-line change in `properties/mod.rs`

## Test plan
- [x] `href_creates_link` — element becomes `<a>` with correct href attribute
- [x] `href_from_class` — href cascades from class to element

All 45 tests pass (43 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)