### PR TITLE
Add target: CUI property for link target attribute

### DIFF
--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -15,6 +15,7 @@ pub enum CuiProperty {
 	Tooltip,
 	Image,
 	Apply,
+	Target,
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Target => quote! { Target },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -42,6 +42,7 @@ impl Property {
 					"tooltip" => CuiProperty::Tooltip,
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
+					"target" => CuiProperty::Target,
 
 					property => panic!(" property not recognized: {}", property),
 				}),
@@ -62,6 +63,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Target => quote! { Target },
 			}
 		} else {
 			quote! {}

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let target = self.properties.get(&Property::Cui(CuiProperty::Target));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"target",
+				&*target
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Target,
 		}
 
 		#[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -122,6 +122,11 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Target => {
+						if let Value::String(s) = value {
+							element.set_attribute("target", s).unwrap();
+						}
+					},
 				}
 			}
 		}

--- a/tests/properties/target.rs
+++ b/tests/properties/target.rs
@@ -1,0 +1,41 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn target_on_link() {
+	test_setup! {
+		item {
+			link: "https://example.com";
+			target: "_blank";
+			text: "external link";
+		}
+	}
+	let element = root
+		.first_element_child()
+		.expect("root should have a child element");
+	assert_eq!(element.tag_name(), "A");
+	assert_eq!(element.get_attribute("href").unwrap(), "https://example.com");
+	assert_eq!(element.get_attribute("target").unwrap(), "_blank");
+}
+
+#[wasm_bindgen_test]
+fn target_from_class() {
+	test_setup! {
+		.external {
+			link: "https://example.com";
+			target: "_blank";
+		}
+		external {}
+	}
+	let element = root
+		.first_element_child()
+		.expect("root should have a child element");
+	assert_eq!(element.tag_name(), "A");
+	assert_eq!(element.get_attribute("target").unwrap(), "_blank");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod target;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- New `target:` CUI property that sets the HTML `target` attribute
- Useful with `link:` / `href:` to control where links open (e.g., `target: "_blank"`)
- Full pipeline: CuiProperty::Target variant, HTML attribute rendering, runtime set_attribute

## Files changed
- `cui.rs` — new Target variant
- `properties/mod.rs` — "target" match + ToTokens
- `wasm/mod.rs` — Target in runtime Property enum
- `html.rs` — target in attributes array
- `render.rs` — render_property sets target attribute

## Test plan
- [x] `target_on_link` — link element has target="_blank" attribute
- [x] `target_from_class` — target cascades from class to element

All 45 tests pass (43 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)