### PR TITLE
Add tabindex: CUI property

### DIFF
--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -15,6 +15,7 @@ pub enum CuiProperty {
 	Tooltip,
 	Image,
 	Apply,
+	Tabindex,
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Tabindex => quote! { Tabindex },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -42,6 +42,7 @@ impl Property {
 					"tooltip" => CuiProperty::Tooltip,
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
+					"tabindex" => CuiProperty::Tabindex,
 
 					property => panic!(" property not recognized: {}", property),
 				}),
@@ -62,6 +63,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Tabindex => quote! { Tabindex },
 			}
 		} else {
 			quote! {}

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let tabindex = self.properties.get(&Property::Cui(CuiProperty::Tabindex));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"tabindex",
+				&*tabindex
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -192,6 +192,13 @@ impl Semantics {
 		// 	effects.push(quote! {});
 		// }
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Tabindex)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value { element.set_attribute("tabindex", s).unwrap(); }
+			});
+		}
+
 		for (property, value) in properties {
 			if let Property::Css(property) = property {
 				let value = self.compiled_dynamic_value(value);

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Tabindex,
 		}
 
 		#[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -122,6 +122,11 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Tabindex => {
+						if let Value::String(s) = value {
+							element.set_attribute("tabindex", s).unwrap();
+						}
+					},
 				}
 			}
 		}

--- a/tests/properties/tabindex.rs
+++ b/tests/properties/tabindex.rs
@@ -1,0 +1,61 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn tabindex_on_element() {
+	test_setup! {
+		item {
+			text: "focusable";
+			tabindex: "0";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("tabindex").expect("should have tabindex"),
+		"0"
+	);
+}
+
+#[wasm_bindgen_test]
+fn tabindex_from_class() {
+	test_setup! {
+		.item {
+			tabindex: "0";
+		}
+		item {
+			text: "click me";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("tabindex").expect("should have tabindex"),
+		"0"
+	);
+}
+
+#[wasm_bindgen_test]
+fn tabindex_negative() {
+	test_setup! {
+		item {
+			text: "not focusable";
+			tabindex: "-1";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("tabindex").expect("should have tabindex"),
+		"-1"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod tabindex;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Adds `tabindex:` as a CUI property for controlling keyboard navigation order
- Supports direct element usage, class cascading, and negative values (`"-1"`)
- Implemented across all codegen paths: static HTML attribute, runtime render, and dynamic initialization

## Test plan
- [x] `tabindex_on_element` — sets tabindex attribute on a div
- [x] `tabindex_from_class` — cascades tabindex from class to matching element
- [x] `tabindex_negative` — supports negative tabindex values
- [x] All 46 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)