### PR TITLE
Add role: CUI property for ARIA roles

### DIFF
--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -15,6 +15,7 @@ pub enum CuiProperty {
 	Tooltip,
 	Image,
 	Apply,
+	Role,
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Role => quote! { Role },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -42,6 +42,7 @@ impl Property {
 					"tooltip" => CuiProperty::Tooltip,
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
+					"role" => CuiProperty::Role,
 
 					property => panic!(" property not recognized: {}", property),
 				}),
@@ -62,6 +63,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Role => quote! { Role },
 			}
 		} else {
 			quote! {}

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let role = self.properties.get(&Property::Cui(CuiProperty::Role));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"role",
+				&*role
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -192,6 +192,13 @@ impl Semantics {
 		// 	effects.push(quote! {});
 		// }
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Role)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value { element.set_attribute("role", s).unwrap(); }
+			});
+		}
+
 		for (property, value) in properties {
 			if let Property::Css(property) = property {
 				let value = self.compiled_dynamic_value(value);

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Role,
 		}
 
 		#[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -122,6 +122,11 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Role => {
+						if let Value::String(s) = value {
+							element.set_attribute("role", s).unwrap();
+						}
+					},
 				}
 			}
 		}

--- a/tests/properties/role.rs
+++ b/tests/properties/role.rs
@@ -1,0 +1,44 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn role_on_element() {
+	test_setup! {
+		nav {
+			role: "navigation";
+			text: "Menu";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("role").expect("should have role"),
+		"navigation"
+	);
+}
+
+#[wasm_bindgen_test]
+fn role_from_class() {
+	test_setup! {
+		.item {
+			role: "button";
+		}
+		item {
+			text: "Click me";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("role").expect("should have role"),
+		"button"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod role;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Adds `role:` as a CUI property for setting ARIA accessibility roles
- Supports direct element usage and class cascading
- Implemented across static HTML, runtime render, and dynamic initialization

## Test plan
- [x] `role_on_element` — sets role attribute directly
- [x] `role_from_class` — cascades role from class to matching element
- [x] All 45 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)