### PR TITLE
Add generic aria-* attribute support

### DIFF
--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -8,13 +8,14 @@ pub enum PageProperty {
 	Title,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum CuiProperty {
 	Text,
 	Link,
 	Tooltip,
 	Image,
 	Apply,
+	Attribute(String),
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Attribute(name) => quote! { Attribute(#name) },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -43,6 +43,10 @@ impl Property {
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
 
+					property if property.starts_with("aria-") => {
+						CuiProperty::Attribute(property.to_string())
+					}
+
 					property => panic!(" property not recognized: {}", property),
 				}),
 			}
@@ -62,6 +66,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Attribute(name) => quote! { Attribute(#name) },
 			}
 		} else {
 			quote! {}

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,20 +58,28 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
-		let attributes = [
-			("style", &*self.properties.css()),
-			("class", &*self.class_names.join(" ")),
+		let empty = Value::Static(StaticValue::String("".to_string()));
+		let mut attr_pairs: Vec<(&str, String)> = vec![
+			("style", self.properties.css()),
+			("class", self.class_names.join(" ")),
 			(
 				"href",
-				&*link
-					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
-					.to_string(),
+				link.unwrap_or(&empty).to_string(),
 			),
-		]
-		.iter()
-		.filter(|(_, value)| !value.is_empty())
-		.map(|(attribute, value)| format!(" {}='{}'", attribute, value))
-		.collect::<String>();
+		];
+
+		// Collect generic attribute properties (aria-*, data-*, etc.)
+		for (property, value) in &self.properties {
+			if let Property::Cui(CuiProperty::Attribute(name)) = property {
+				attr_pairs.push((name, value.to_string()));
+			}
+		}
+
+		let attributes = attr_pairs
+			.iter()
+			.filter(|(_, value)| !value.is_empty())
+			.map(|(attribute, value)| format!(" {}='{}'", attribute, value))
+			.collect::<String>();
 
 		let children = (self.elements.iter())
 			.filter(|&&element_id| groups[element_id].is_compiled())

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -193,9 +193,18 @@ impl Semantics {
 		// }
 
 		for (property, value) in properties {
-			if let Property::Css(property) = property {
-				let value = self.compiled_dynamic_value(value);
-				effects.push(quote! { element.css(#property, #value); });
+			match property {
+				Property::Css(property) => {
+					let value = self.compiled_dynamic_value(value);
+					effects.push(quote! { element.css(#property, #value); });
+				}
+				Property::Cui(CuiProperty::Attribute(name)) => {
+					let value = self.compiled_dynamic_value(value);
+					effects.push(quote! {
+						if let Value::String(s) = #value { element.set_attribute(#name, s).unwrap(); }
+					});
+				}
+				_ => {}
 			}
 		}
 		effects.into_iter().collect()

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Attribute(&'static str),
 		}
 
 		#[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -122,6 +122,11 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Attribute(name) => {
+						if let Value::String(s) = value {
+							element.set_attribute(name, s).unwrap();
+						}
+					},
 				}
 			}
 		}

--- a/tests/properties/aria.rs
+++ b/tests/properties/aria.rs
@@ -1,0 +1,61 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn aria_label_on_element() {
+	test_setup! {
+		nav {
+			aria-label: "Main navigation";
+			text: "Home";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("aria-label").expect("should have aria-label"),
+		"Main navigation"
+	);
+}
+
+#[wasm_bindgen_test]
+fn aria_label_from_class() {
+	test_setup! {
+		.item {
+			aria-label: "Menu item";
+		}
+		item {
+			text: "Click me";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("aria-label").expect("should have aria-label"),
+		"Menu item"
+	);
+}
+
+#[wasm_bindgen_test]
+fn aria_hidden_on_element() {
+	test_setup! {
+		decorative {
+			aria-hidden: "true";
+			text: "decorative";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("aria-hidden").expect("should have aria-hidden"),
+		"true"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod aria;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Introduces `CuiProperty::Attribute(String)` for generic HTML attribute properties
- Any `aria-*` property (e.g. `aria-label:`, `aria-hidden:`) is now handled automatically
- Removes `Copy` from `CuiProperty` to support the `String` variant
- Extensible: same mechanism can later support `data-*` and other generic attributes

## Test plan
- [x] `aria_label_on_element` — sets aria-label attribute directly
- [x] `aria_label_from_class` — cascades aria-label from class to element
- [x] `aria_hidden_on_element` — sets aria-hidden attribute
- [x] All 46 tests pass (43 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)