### PR TITLE
Add scroll, contextmenu, wheel, and touch events

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -102,6 +102,12 @@ impl Semantics {
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
+					"scroll" => quote! { set_onscroll },
+					"contextmenu" => quote! { set_oncontextmenu },
+					"wheel" => quote! { set_onwheel },
+					"touchstart" => quote! { set_ontouchstart },
+					"touchend" => quote! { set_ontouchend },
+					"touchmove" => quote! { set_ontouchmove },
 					_ => panic!("unknown event id"),
 				};
 

--- a/tests/misc/more_events.rs
+++ b/tests/misc/more_events.rs
@@ -1,0 +1,36 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn contextmenu_event() {
+	test_setup! {
+		text: "right click me";
+		?contextmenu {
+			text: "context menu opened";
+		}
+	}
+	assert_eq!(root.inner_html(), "right click me");
+	let event = Event::new("contextmenu").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "context menu opened");
+}
+
+#[wasm_bindgen_test]
+fn wheel_event() {
+	test_setup! {
+		text: "scroll wheel";
+		?wheel {
+			text: "wheel scrolled";
+		}
+	}
+	assert_eq!(root.inner_html(), "scroll wheel");
+	let event = Event::new("wheel").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "wheel scrolled");
+}

--- a/tests/misc/scroll_event.rs
+++ b/tests/misc/scroll_event.rs
@@ -1,0 +1,22 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn scroll_event() {
+	test_setup! {
+		text: "not scrolled";
+		?scroll {
+			text: "scrolled";
+		}
+	}
+	assert_eq!(root.inner_html(), "not scrolled");
+	let event = Event::new("scroll").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "scrolled");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,8 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod more_events;
+	mod scroll_event;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds 6 new event listener types: `?scroll`, `?contextmenu`, `?wheel`, `?touchstart`, `?touchend`, `?touchmove`
- Touch events compile correctly but can't be tested in headless Chrome
- Brings total supported events to 14

## Test plan
- [x] `scroll_event` — dispatches scroll event, verifies text update
- [x] `contextmenu_event` — dispatches contextmenu event
- [x] `wheel_event` — dispatches wheel event
- [x] All 46 tests pass (43 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)