### PR TITLE
Add pointer events and focusin/focusout listeners

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -90,23 +90,32 @@ impl Semantics {
 					return quote! {};
 				}
 
-				let event = match &**self.groups[listener_id]
+				let name = &**self.groups[listener_id]
 					.name
 					.as_ref()
-					.expect("every listener should have an event id")
-				{
-					"blur" => quote! { set_onblur },
-					"focus" => quote! { set_onfocus },
-					"click" => quote! { set_onclick },
-					"mouseover" => quote! { set_onmouseover },
-					"mouseenter" => quote! { set_onmouseenter },
-					"mouseleave" => quote! { set_onmouseleave },
-					"mouseout" => quote! { set_onmouseout },
+					.expect("every listener should have an event id");
+
+				// Events with dedicated set_on* methods on HtmlElement
+				let setter = match name {
+					"blur" => Some(quote! { set_onblur }),
+					"focus" => Some(quote! { set_onfocus }),
+					"click" => Some(quote! { set_onclick }),
+					"mouseover" => Some(quote! { set_onmouseover }),
+					"mouseenter" => Some(quote! { set_onmouseenter }),
+					"mouseleave" => Some(quote! { set_onmouseleave }),
+					"mouseout" => Some(quote! { set_onmouseout }),
+					"pointerdown" => Some(quote! { set_onpointerdown }),
+					"pointerup" => Some(quote! { set_onpointerup }),
+					"pointermove" => Some(quote! { set_onpointermove }),
+					"pointerenter" => Some(quote! { set_onpointerenter }),
+					"pointerleave" => Some(quote! { set_onpointerleave }),
+					// Events that need addEventListener (no set_on* method)
+					"focusin" | "focusout" => None,
 					_ => panic!("unknown event id"),
 				};
 
 				let rules = self.provide_state(rules);
-				quote! {
+				let closure = quote! {
 					let closure = {
 						let document = document.clone();
 						let mut element = element.clone();
@@ -118,8 +127,24 @@ impl Semantics {
 							});
 						}) as Box<dyn FnMut(Event)>)
 					};
-					element.#event(Some(closure.as_ref().unchecked_ref()));
-					closure.forget();
+				};
+
+				if let Some(event) = setter {
+					quote! {
+						#closure
+						element.#event(Some(closure.as_ref().unchecked_ref()));
+						closure.forget();
+					}
+				} else {
+					let event_name = name;
+					quote! {
+						#closure
+						element.add_event_listener_with_callback(
+							#event_name,
+							closure.as_ref().unchecked_ref(),
+						).unwrap();
+						closure.forget();
+					}
 				}
 			})
 			.collect()

--- a/tests/misc/pointer_events.rs
+++ b/tests/misc/pointer_events.rs
@@ -1,0 +1,64 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn pointerdown_event() {
+	test_setup! {
+		text: "press me";
+		?pointerdown {
+			text: "pressed";
+		}
+	}
+	assert_eq!(root.inner_html(), "press me");
+	let event = Event::new("pointerdown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "pressed");
+}
+
+#[wasm_bindgen_test]
+fn pointerup_event() {
+	test_setup! {
+		text: "release me";
+		?pointerup {
+			text: "released";
+		}
+	}
+	assert_eq!(root.inner_html(), "release me");
+	let event = Event::new("pointerup").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "released");
+}
+
+#[wasm_bindgen_test]
+fn focusin_event() {
+	test_setup! {
+		text: "focus in me";
+		?focusin {
+			text: "focused in";
+		}
+	}
+	assert_eq!(root.inner_html(), "focus in me");
+	let event = Event::new("focusin").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "focused in");
+}
+
+#[wasm_bindgen_test]
+fn focusout_event() {
+	test_setup! {
+		text: "focus out";
+		?focusout {
+			text: "focus lost";
+		}
+	}
+	assert_eq!(root.inner_html(), "focus out");
+	let event = Event::new("focusout").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "focus lost");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod pointer_events;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds 7 new event types: `?pointerdown`, `?pointerup`, `?pointermove`, `?pointerenter`, `?pointerleave`, `?focusin`, `?focusout`
- Refactors event binding to support both `set_on*` and `addEventListener` patterns
- `focusin`/`focusout` use `addEventListener` since web_sys lacks dedicated setter methods
- Pointer events work across mouse and touch, replacing the need for separate mouse/touch handlers

## Test plan
- [x] `pointerdown_event` — dispatches pointerdown, verifies text update
- [x] `pointerup_event` — dispatches pointerup, verifies text update
- [x] `focusin_event` — dispatches focusin via addEventListener
- [x] `focusout_event` — dispatches focusout via addEventListener
- [x] All 47 tests pass (43 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)