### PR TITLE
Support any unknown property as generic HTML attribute

### DIFF
--- a/src/data/semantics/properties/cui.rs
+++ b/src/data/semantics/properties/cui.rs
@@ -8,13 +8,14 @@ pub enum PageProperty {
 	Title,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum CuiProperty {
 	Text,
 	Link,
 	Tooltip,
 	Image,
 	Apply,
+	Attribute(String),
 }
 
 impl ToTokens for CuiProperty {
@@ -25,6 +26,7 @@ impl ToTokens for CuiProperty {
 			Self::Tooltip => quote! { Tooltip },
 			Self::Image => quote! { Image },
 			Self::Apply => quote! { Apply },
+			Self::Attribute(name) => quote! { Attribute(#name) },
 		}
 		.to_tokens(tokens)
 	}

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -43,7 +43,8 @@ impl Property {
 					"image" => CuiProperty::Image,
 					"apply" => CuiProperty::Apply,
 
-					property => panic!(" property not recognized: {}", property),
+					// Any unrecognized property becomes a generic HTML attribute
+					property => CuiProperty::Attribute(property.to_string()),
 				}),
 			}
 		}
@@ -62,6 +63,7 @@ impl ToTokens for Property {
 				CuiProperty::Tooltip => quote! { Tooltip },
 				CuiProperty::Image => quote! { Image },
 				CuiProperty::Apply => quote! { Apply },
+				CuiProperty::Attribute(name) => quote! { Attribute(#name) },
 			}
 		} else {
 			quote! {}

--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,20 +58,28 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
-		let attributes = [
-			("style", &*self.properties.css()),
-			("class", &*self.class_names.join(" ")),
+		let empty = Value::Static(StaticValue::String("".to_string()));
+		let mut attr_pairs: Vec<(&str, String)> = vec![
+			("style", self.properties.css()),
+			("class", self.class_names.join(" ")),
 			(
 				"href",
-				&*link
-					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
-					.to_string(),
+				link.unwrap_or(&empty).to_string(),
 			),
-		]
-		.iter()
-		.filter(|(_, value)| !value.is_empty())
-		.map(|(attribute, value)| format!(" {}='{}'", attribute, value))
-		.collect::<String>();
+		];
+
+		// Collect generic attribute properties (aria-*, data-*, role, tabindex, etc.)
+		for (property, value) in &self.properties {
+			if let Property::Cui(CuiProperty::Attribute(name)) = property {
+				attr_pairs.push((name, value.to_string()));
+			}
+		}
+
+		let attributes = attr_pairs
+			.iter()
+			.filter(|(_, value)| !value.is_empty())
+			.map(|(attribute, value)| format!(" {}='{}'", attribute, value))
+			.collect::<String>();
 
 		let children = (self.elements.iter())
 			.filter(|&&element_id| groups[element_id].is_compiled())

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -193,9 +193,18 @@ impl Semantics {
 		// }
 
 		for (property, value) in properties {
-			if let Property::Css(property) = property {
-				let value = self.compiled_dynamic_value(value);
-				effects.push(quote! { element.css(#property, #value); });
+			match property {
+				Property::Css(property) => {
+					let value = self.compiled_dynamic_value(value);
+					effects.push(quote! { element.css(#property, #value); });
+				}
+				Property::Cui(CuiProperty::Attribute(name)) => {
+					let value = self.compiled_dynamic_value(value);
+					effects.push(quote! {
+						if let Value::String(s) = #value { element.set_attribute(#name, s).unwrap(); }
+					});
+				}
+				_ => {}
 			}
 		}
 		effects.into_iter().collect()

--- a/src/transform/compile/wasm/mod.rs
+++ b/src/transform/compile/wasm/mod.rs
@@ -37,6 +37,7 @@ fn header() -> TokenStream {
 			Tooltip,
 			Image,
 			Apply,
+			Attribute(&'static str),
 		}
 
 		#[derive(Clone, Debug)]

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -122,6 +122,11 @@ impl Semantics {
 					Property::Tooltip => (),
 					Property::Image => (),
 					Property::Apply => (),
+					Property::Attribute(name) => {
+						if let Value::String(s) = value {
+							element.set_attribute(name, s).unwrap();
+						}
+					},
 				}
 			}
 		}

--- a/tests/properties/attributes.rs
+++ b/tests/properties/attributes.rs
@@ -1,0 +1,95 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn aria_label() {
+	test_setup! {
+		item {
+			aria-label: "Main navigation";
+			text: "Home";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("aria-label").expect("should have aria-label"),
+		"Main navigation"
+	);
+}
+
+#[wasm_bindgen_test]
+fn data_attribute() {
+	test_setup! {
+		item {
+			data-id: "42";
+			text: "Item";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("data-id").expect("should have data-id"),
+		"42"
+	);
+}
+
+#[wasm_bindgen_test]
+fn role_attribute() {
+	test_setup! {
+		nav {
+			role: "navigation";
+			text: "Menu";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("role").expect("should have role"),
+		"navigation"
+	);
+}
+
+#[wasm_bindgen_test]
+fn tabindex_attribute() {
+	test_setup! {
+		item {
+			tabindex: "0";
+			text: "Focusable";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("tabindex").expect("should have tabindex"),
+		"0"
+	);
+}
+
+#[wasm_bindgen_test]
+fn attribute_from_class() {
+	test_setup! {
+		.item {
+			data-category: "button";
+		}
+		item {
+			text: "Click";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	assert_eq!(
+		el.get_attribute("data-category").expect("should have data-category"),
+		"button"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod attributes;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- **Breaking change**: Unknown properties no longer panic at compile time
- Any unrecognized property name (not CSS, not a known CUI property) becomes an HTML attribute
- `role:`, `tabindex:`, `aria-label:`, `data-id:`, etc. all work automatically
- Introduces `CuiProperty::Attribute(String)` variant and `Property::Attribute(&'static str)` in runtime
- Known CUI properties (`text`, `link`, `tooltip`, `image`, `apply`) keep their specialized behavior
- This is the property-side analog of PR #94's generic event support

## Test plan
- [x] `aria_label` — sets aria-label attribute on element
- [x] `data_attribute` — sets data-id attribute
- [x] `role_attribute` — sets role attribute
- [x] `tabindex_attribute` — sets tabindex attribute
- [x] `attribute_from_class` — cascades data-category from class to element
- [x] All 48 tests pass (43 existing + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)