### PR TITLE
Fix parsing of Rust keywords in property names

### DIFF
--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -85,11 +85,12 @@ impl Parse for Block {
 
 impl Parse for Property {
 	fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-		// Parse hyphenated property names like font-family, max-width, etc.
-		let mut property = input.parse::<Ident>()?.to_string();
+		// Parse hyphenated property names like font-family, max-width, list-style-type, etc.
+		// Use parse_any to accept Rust keywords (e.g. "type" in "list-style-type")
+		let mut property = Ident::parse_any(input)?.to_string();
 		while input.peek(Token![-]) {
 			input.parse::<Token![-]>()?;
-			let next = input.parse::<Ident>()?;
+			let next = Ident::parse_any(input)?;
 			property.push('-');
 			property.push_str(&next.to_string());
 		}

--- a/tests/properties/keyword_names.rs
+++ b/tests/properties/keyword_names.rs
@@ -1,0 +1,25 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn list_style_type() {
+	test_setup! {
+		item {
+			list-style-type: "none";
+		}
+	}
+	let el = root
+		.first_element_child()
+		.expect("root should have a child");
+	let style = window.get_computed_style(&el).unwrap().unwrap();
+	assert_eq!(
+		style.get_property_value("list-style-type").unwrap(),
+		"none"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod keyword_names;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Fixes a bug where Rust keywords in hyphenated property names caused parse errors
- `list-style-type`, `align-self`, `data-type`, etc. now parse correctly
- Uses `Ident::parse_any` (from `syn::ext::IdentExt`, already imported) instead of `Ident::parse`
- Two-line fix in the property parser

## Test plan
- [x] `list_style_type` — CSS property with Rust keyword `type` as segment
- [x] All 44 tests pass (43 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)