### PR TITLE
Add mousedown, mouseup, and mousemove events

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -102,6 +102,9 @@ impl Semantics {
 					"mouseenter" => quote! { set_onmouseenter },
 					"mouseleave" => quote! { set_onmouseleave },
 					"mouseout" => quote! { set_onmouseout },
+					"mousedown" => quote! { set_onmousedown },
+					"mouseup" => quote! { set_onmouseup },
+					"mousemove" => quote! { set_onmousemove },
 					_ => panic!("unknown event id"),
 				};
 

--- a/tests/misc/mouse_buttons.rs
+++ b/tests/misc/mouse_buttons.rs
@@ -1,0 +1,50 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn mousedown_event() {
+	test_setup! {
+		text: "press me";
+		?mousedown {
+			text: "mouse down";
+		}
+	}
+	assert_eq!(root.inner_html(), "press me");
+	let event = Event::new("mousedown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "mouse down");
+}
+
+#[wasm_bindgen_test]
+fn mouseup_event() {
+	test_setup! {
+		text: "release me";
+		?mouseup {
+			text: "mouse up";
+		}
+	}
+	assert_eq!(root.inner_html(), "release me");
+	let event = Event::new("mouseup").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "mouse up");
+}
+
+#[wasm_bindgen_test]
+fn mousemove_event() {
+	test_setup! {
+		text: "move mouse";
+		?mousemove {
+			text: "mouse moved";
+		}
+	}
+	assert_eq!(root.inner_html(), "move mouse");
+	let event = Event::new("mousemove").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "mouse moved");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod mouse_buttons;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds `?mousedown`, `?mouseup`, and `?mousemove` event listeners
- Completes the mouse event set (click, mouseover, mouseenter, mouseleave, mouseout + these 3)
- Essential for drag-and-drop patterns and press-and-hold interactions

## Test plan
- [x] `mousedown_event` — dispatches mousedown, verifies text update
- [x] `mouseup_event` — dispatches mouseup, verifies text update
- [x] `mousemove_event` — dispatches mousemove, verifies text update
- [x] All 46 tests pass (43 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)