### PR TITLE
Add multi-variable test coverage

### DIFF
--- a/tests/data/multi_variable.rs
+++ b/tests/data/multi_variable.rs
@@ -1,0 +1,99 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// Two independent variables, each updated by different elements
+#[wasm_bindgen_test]
+fn two_variables_independent() {
+	test_setup! {
+		let $a: "initial-a";
+		let $b: "initial-b";
+		first {
+			text: $a;
+			?click {
+				$a: "updated-a";
+			}
+		}
+		second {
+			text: $b;
+			?click {
+				$b: "updated-b";
+			}
+		}
+	}
+	let first = root.children().item(0).unwrap();
+	let second = root.children().item(1).unwrap();
+	assert_eq!(first.inner_html(), "initial-a");
+	assert_eq!(second.inner_html(), "initial-b");
+
+	first.dyn_into::<HtmlElement>().unwrap().click();
+	let first = root.children().item(0).unwrap();
+	let second = root.children().item(1).unwrap();
+	assert_eq!(first.inner_html(), "updated-a");
+	assert_eq!(second.inner_html(), "initial-b");
+
+	second.dyn_into::<HtmlElement>().unwrap().click();
+	let second = root.children().item(1).unwrap();
+	assert_eq!(second.inner_html(), "updated-b");
+}
+
+/// One variable read by multiple elements, updated by one
+#[wasm_bindgen_test]
+fn shared_variable_multiple_readers() {
+	test_setup! {
+		let $msg: "hello";
+		first {
+			text: $msg;
+		}
+		second {
+			text: $msg;
+		}
+		button {
+			text: "click";
+			?click {
+				$msg: "world";
+			}
+		}
+	}
+	let first = root.children().item(0).unwrap();
+	let second = root.children().item(1).unwrap();
+	assert_eq!(first.inner_html(), "hello");
+	assert_eq!(second.inner_html(), "hello");
+
+	let button = root.children().item(2).unwrap();
+	button.dyn_into::<HtmlElement>().unwrap().click();
+
+	let first = root.children().item(0).unwrap();
+	let second = root.children().item(1).unwrap();
+	assert_eq!(first.inner_html(), "world");
+	assert_eq!(second.inner_html(), "world");
+}
+
+/// Variable used for CSS property, updated on click
+#[wasm_bindgen_test]
+fn variable_css_toggle() {
+	test_setup! {
+		let $bg: "red";
+		background-color: $bg;
+		text: "click to toggle";
+		?click {
+			$bg: "blue";
+		}
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(
+		style.get_property_value("background-color").unwrap(),
+		"rgb(255, 0, 0)"
+	);
+	root.click();
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(
+		style.get_property_value("background-color").unwrap(),
+		"rgb(0, 0, 255)"
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ mod classes {
 mod data {
 	mod apply;
 	mod dynamic;
+	mod multi_variable;
 	mod r#static;
 }
 mod misc {


### PR DESCRIPTION
## Summary
- Adds 3 new tests for the mutable variable system covering patterns not previously tested
- `two_variables_independent`: two separate mutable variables updated by different child elements
- `shared_variable_multiple_readers`: one variable read by multiple elements, updated by a third
- `variable_css_toggle`: mutable variable driving a CSS property (background-color), toggled on click

## Test plan
- [x] All 46 tests pass (`wasm-pack test --headless --chrome`)
- [x] No compiler changes needed (coverage tests for existing functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)