### PR TITLE
Add link: property test coverage

### DIFF
--- a/tests/properties/link.rs
+++ b/tests/properties/link.rs
@@ -1,0 +1,52 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// link: property should create an <a> tag with href attribute
+#[wasm_bindgen_test]
+fn link_creates_anchor() {
+	test_setup! {
+		link: "https://example.com";
+		text: "click here";
+	}
+	assert_eq!(root.tag_name(), "A");
+	assert_eq!(root.get_attribute("href").unwrap(), "https://example.com");
+	assert_eq!(root.inner_html(), "click here");
+}
+
+/// link: on a child element should make only that child an <a> tag
+#[wasm_bindgen_test]
+fn link_on_child() {
+	test_setup! {
+		child {
+			link: "https://example.com";
+			text: "link text";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.tag_name(), "A");
+	assert_eq!(child.get_attribute("href").unwrap(), "https://example.com");
+	// Parent should remain a div
+	assert_eq!(root.tag_name(), "DIV");
+}
+
+/// link: from a class should cascade to matching elements
+#[wasm_bindgen_test]
+fn link_from_class() {
+	test_setup! {
+		.nav {
+			link: "https://example.com";
+		}
+		nav {
+			text: "navigation";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.tag_name(), "A");
+	assert_eq!(child.get_attribute("href").unwrap(), "https://example.com");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod link;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Adds 3 tests for the `link:` property which had zero test coverage
- `link_creates_anchor`: verifies link creates `<a>` tag with correct `href` attribute
- `link_on_child`: verifies link on child element makes only that child an `<a>`, parent stays `<div>`
- `link_from_class`: verifies link property cascades from class to matching element

## Test plan
- [x] All 46 tests pass (`wasm-pack test --headless --chrome`)
- [x] No compiler changes needed (coverage tests for existing functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)