### PR TITLE
Replace panic with compile_error for unknown properties

### DIFF
--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -17,8 +17,8 @@ pub struct Page {
 
 #[derive(Default)]
 pub struct Semantics {
-	pub errors: Vec<&'static str>,
-	pub warnings: Vec<&'static str>,
+	pub errors: Vec<String>,
+	pub warnings: Vec<String>,
 	pub styles: CssRules,
 
 	pub pages: Vec<Page>,

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -29,22 +29,25 @@ fn is_css_property(name: &str) -> bool {
 }
 
 impl Property {
-	pub fn new(property: String) -> Self {
+	pub fn new(property: String) -> Result<Self, String> {
 		if is_css_property(&property) {
-			Self::Css(property)
+			Ok(Self::Css(property))
 		} else {
 			match property.as_str() {
-				"title" => Self::Page(PageProperty::Title),
+				"title" => Ok(Self::Page(PageProperty::Title)),
 
-				property => Self::Cui(match property {
-					"text" => CuiProperty::Text,
-					"link" => CuiProperty::Link,
-					"tooltip" => CuiProperty::Tooltip,
-					"image" => CuiProperty::Image,
-					"apply" => CuiProperty::Apply,
+				property => match property {
+					"text" => Ok(Self::Cui(CuiProperty::Text)),
+					"link" => Ok(Self::Cui(CuiProperty::Link)),
+					"tooltip" => Ok(Self::Cui(CuiProperty::Tooltip)),
+					"image" => Ok(Self::Cui(CuiProperty::Image)),
+					"apply" => Ok(Self::Cui(CuiProperty::Apply)),
 
-					property => panic!(" property not recognized: {}", property),
-				}),
+					property => Err(format!(
+						"property not recognized: `{}`. Use a CSS property name or a CUI property (text, link, tooltip, image, apply).",
+						property
+					)),
+				},
 			}
 		}
 	}

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -108,11 +108,17 @@ impl Semantics {
 				group_id
 			);
 			let value = self.create_semantic_value(&value);
-			let property = Property::new(property);
-			if let Property::Css(_) = property {
-				self.groups[group_id].has_css_properties = true;
+			match Property::new(property) {
+				Ok(property) => {
+					if let Property::Css(_) = property {
+						self.groups[group_id].has_css_properties = true;
+					}
+					self.groups[group_id].properties.insert(property, value);
+				}
+				Err(error) => {
+					self.errors.push(error);
+				}
 			}
-			self.groups[group_id].properties.insert(property, value);
 		}
 
 		for block in block.listeners {


### PR DESCRIPTION
## Summary
- `Property::new()` previously called `panic!()` on unrecognized property names, crashing the compiler
- Now returns `Result<Self, String>` — errors are collected and emitted as `compile_error!` diagnostics
- Error message includes the property name and lists valid CUI properties
- Changed `errors`/`warnings` from `Vec<&'static str>` to `Vec<String>` to support dynamic messages

## Test plan
- [x] All 43 tests pass (`wasm-pack test --headless --chrome`)
- [x] No regressions in existing functionality
- [x] Unknown properties now produce helpful compile errors instead of panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)