### PR TITLE
Add 13 new events and addEventListener fallback

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -90,23 +90,37 @@ impl Semantics {
 					return quote! {};
 				}
 
-				let event = match &**self.groups[listener_id]
+				let name = &**self.groups[listener_id]
 					.name
 					.as_ref()
-					.expect("every listener should have an event id")
-				{
-					"blur" => quote! { set_onblur },
-					"focus" => quote! { set_onfocus },
-					"click" => quote! { set_onclick },
-					"mouseover" => quote! { set_onmouseover },
-					"mouseenter" => quote! { set_onmouseenter },
-					"mouseleave" => quote! { set_onmouseleave },
-					"mouseout" => quote! { set_onmouseout },
-					_ => panic!("unknown event id"),
+					.expect("every listener should have an event id");
+
+				let setter = match name {
+					"blur" => Some(quote! { set_onblur }),
+					"focus" => Some(quote! { set_onfocus }),
+					"click" => Some(quote! { set_onclick }),
+					"dblclick" => Some(quote! { set_ondblclick }),
+					"mousedown" => Some(quote! { set_onmousedown }),
+					"mouseup" => Some(quote! { set_onmouseup }),
+					"mousemove" => Some(quote! { set_onmousemove }),
+					"mouseover" => Some(quote! { set_onmouseover }),
+					"mouseenter" => Some(quote! { set_onmouseenter }),
+					"mouseleave" => Some(quote! { set_onmouseleave }),
+					"mouseout" => Some(quote! { set_onmouseout }),
+					"keydown" => Some(quote! { set_onkeydown }),
+					"keyup" => Some(quote! { set_onkeyup }),
+					"keypress" => Some(quote! { set_onkeypress }),
+					"input" => Some(quote! { set_oninput }),
+					"change" => Some(quote! { set_onchange }),
+					"submit" => Some(quote! { set_onsubmit }),
+					"scroll" => Some(quote! { set_onscroll }),
+					"contextmenu" => Some(quote! { set_oncontextmenu }),
+					"wheel" => Some(quote! { set_onwheel }),
+					_ => None,
 				};
 
 				let rules = self.provide_state(rules);
-				quote! {
+				let closure = quote! {
 					let closure = {
 						let document = document.clone();
 						let mut element = element.clone();
@@ -118,8 +132,24 @@ impl Semantics {
 							});
 						}) as Box<dyn FnMut(Event)>)
 					};
-					element.#event(Some(closure.as_ref().unchecked_ref()));
-					closure.forget();
+				};
+
+				if let Some(event) = setter {
+					quote! {
+						#closure
+						element.#event(Some(closure.as_ref().unchecked_ref()));
+						closure.forget();
+					}
+				} else {
+					let event_name = name;
+					quote! {
+						#closure
+						element.add_event_listener_with_callback(
+							#event_name,
+							closure.as_ref().unchecked_ref(),
+						).unwrap();
+						closure.forget();
+					}
 				}
 			})
 			.collect()

--- a/tests/misc/additional_events.rs
+++ b/tests/misc/additional_events.rs
@@ -1,0 +1,68 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// dblclick event should trigger handler
+#[wasm_bindgen_test]
+fn dblclick_event() {
+	test_setup! {
+		text: "waiting";
+		?dblclick {
+			text: "double clicked";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	let event = Event::new("dblclick").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "double clicked");
+}
+
+/// mousedown event should trigger handler
+#[wasm_bindgen_test]
+fn mousedown_event() {
+	test_setup! {
+		text: "waiting";
+		?mousedown {
+			text: "mouse down";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	let event = Event::new("mousedown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "mouse down");
+}
+
+/// keydown event should trigger handler
+#[wasm_bindgen_test]
+fn keydown_event() {
+	test_setup! {
+		text: "waiting";
+		?keydown {
+			text: "key pressed";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	let event = Event::new("keydown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "key pressed");
+}
+
+/// input event should trigger handler
+#[wasm_bindgen_test]
+fn input_event() {
+	test_setup! {
+		text: "waiting";
+		?input {
+			text: "input received";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	let event = Event::new("input").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "input received");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,6 +13,7 @@ mod data {
 	mod r#static;
 }
 mod misc {
+	mod additional_events;
 	mod basics;
 	mod complex;
 	mod events;


### PR DESCRIPTION
## Summary
- Expands event support from 7 hardcoded events to 20 with dedicated `set_on*` setters
- Adds `addEventListener` fallback for ANY event not in the hardcoded set (replaces panic)
- New events with dedicated setters: dblclick, mousedown, mouseup, mousemove, keydown, keyup, keypress, input, change, submit, scroll, contextmenu, wheel
- Any other event name (e.g., `?animationend`, `?transitionend`, custom events) now works via `addEventListener` instead of crashing

## Test plan
- [x] All 47 tests pass (`wasm-pack test --headless --chrome`)
- [x] 4 new tests: dblclick, mousedown, keydown, input events
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)