### PR TITLE
Implement tooltip: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,14 +58,18 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let tooltip = self.properties.get(&Property::Cui(CuiProperty::Tooltip));
+		let empty = Value::Static(StaticValue::String("".to_string()));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
-				&*link
-					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
-					.to_string(),
+				&*link.unwrap_or(&empty).to_string(),
+			),
+			(
+				"title",
+				&*tooltip.unwrap_or(&empty).to_string(),
 			),
 		]
 		.iter()

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,15 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Tooltip)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value {
+					element.set_title(s);
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -119,7 +119,11 @@ impl Semantics {
 					Property::Css(property) => element.css(property, value),
 					Property::Link => (),
 					Property::Text => element.text(value),
-					Property::Tooltip => (),
+					Property::Tooltip => {
+						if let Value::String(s) = value {
+							element.set_title(s);
+						}
+					},
 					Property::Image => (),
 					Property::Apply => (),
 				}

--- a/tests/properties/tooltip.rs
+++ b/tests/properties/tooltip.rs
@@ -1,0 +1,46 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// tooltip: should set the HTML title attribute for hover text
+#[wasm_bindgen_test]
+fn tooltip_sets_title() {
+	test_setup! {
+		text: "hover me";
+		tooltip: "This is a tooltip";
+	}
+	assert_eq!(root.title(), "This is a tooltip");
+}
+
+/// tooltip: on a child element
+#[wasm_bindgen_test]
+fn tooltip_on_child() {
+	test_setup! {
+		child {
+			text: "hover me";
+			tooltip: "Child tooltip";
+		}
+	}
+	let child = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	assert_eq!(child.title(), "Child tooltip");
+}
+
+/// tooltip: from a class should cascade to matching elements
+#[wasm_bindgen_test]
+fn tooltip_from_class() {
+	test_setup! {
+		.tip {
+			tooltip: "Class tooltip";
+		}
+		tip {
+			text: "hover me";
+		}
+	}
+	let child = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	assert_eq!(child.title(), "Class tooltip");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,4 +20,5 @@ mod misc {
 mod properties {
 	mod text;
 	mod title;
+	mod tooltip;
 }


### PR DESCRIPTION
## Summary
- Implements the `tooltip:` property which was previously parsed but generated no output
- Static HTML: emits `title='...'` attribute on the element
- Runtime: calls `element.set_title()` for dynamic rendering
- Dynamic codegen: handles tooltip in `compiled_dynamic_properties` for listener-created elements
- Tooltip cascades from classes to matching elements (same as text, link, etc.)

## Test plan
- [x] All 46 tests pass (`wasm-pack test --headless --chrome`)
- [x] 3 new tests: basic tooltip, child element tooltip, class-cascaded tooltip
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)