### PR TITLE
Implement image: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,14 +58,23 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let empty = Value::Static(StaticValue::String("".to_string()));
+
+		// Build inline style: CSS properties + image background if present
+		let mut inline_style = self.properties.css();
+		if let Some(image_value) = self.properties.get(&Property::Cui(CuiProperty::Image)) {
+			let url = image_value.to_string();
+			if !url.is_empty() {
+				inline_style.push_str(&format!("background-image:url({});background-size:cover;", url));
+			}
+		}
+
 		let attributes = [
-			("style", &*self.properties.css()),
+			("style", &*inline_style),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
-				&*link
-					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
-					.to_string(),
+				&*link.unwrap_or(&empty).to_string(),
 			),
 		]
 		.iter()

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,16 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Image)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(url) = #value {
+					element.style().set_property("background-image", &format!("url({})", url)).unwrap();
+					element.style().set_property("background-size", "cover").unwrap();
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -120,7 +120,12 @@ impl Semantics {
 					Property::Link => (),
 					Property::Text => element.text(value),
 					Property::Tooltip => (),
-					Property::Image => (),
+					Property::Image => {
+						if let Value::String(url) = value {
+							element.style().set_property("background-image", &format!("url({})", url)).unwrap();
+							element.style().set_property("background-size", "cover").unwrap();
+						}
+					},
 					Property::Apply => (),
 				}
 			}

--- a/tests/properties/image.rs
+++ b/tests/properties/image.rs
@@ -1,0 +1,45 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// image: should set background-image CSS property
+#[wasm_bindgen_test]
+fn image_sets_background() {
+	test_setup! {
+		image: "https://example.com/photo.jpg";
+		width: "100px";
+		height: "100px";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	let bg = style.get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("https://example.com/photo.jpg"),
+		"background-image should contain the URL, got: {}",
+		bg
+	);
+}
+
+/// image: on a child element
+#[wasm_bindgen_test]
+fn image_on_child() {
+	test_setup! {
+		child {
+			image: "https://example.com/photo.jpg";
+			width: "50px";
+			height: "50px";
+		}
+	}
+	let child = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	let style = window.get_computed_style(&child).unwrap().unwrap();
+	let bg = style.get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("https://example.com/photo.jpg"),
+		"background-image should contain the URL, got: {}",
+		bg
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod image;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Implements the `image:` property which was previously parsed but generated no output
- Sets `background-image: url(...)` and `background-size: cover` as inline styles
- Works in static HTML output, runtime render, and dynamic codegen paths
- Design choice: uses background-image instead of creating `<img>` tags for simplicity

## Test plan
- [x] All 45 tests pass (`wasm-pack test --headless --chrome`)
- [x] 2 new tests: basic image, child element image
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)