### PR TITLE
Fix Rust keyword parsing in property names

### DIFF
--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -86,10 +86,11 @@ impl Parse for Block {
 impl Parse for Property {
 	fn parse(input: ParseStream) -> Result<Self, syn::Error> {
 		// Parse hyphenated property names like font-family, max-width, etc.
-		let mut property = input.parse::<Ident>()?.to_string();
+		// Use parse_any to accept Rust keywords (e.g., "float", "type", "self")
+		let mut property = Ident::parse_any(input)?.to_string();
 		while input.peek(Token![-]) {
 			input.parse::<Token![-]>()?;
-			let next = input.parse::<Ident>()?;
+			let next = Ident::parse_any(input)?;
 			property.push('-');
 			property.push_str(&next.to_string());
 		}

--- a/tests/properties/keyword_names.rs
+++ b/tests/properties/keyword_names.rs
@@ -1,0 +1,21 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// Property names that are Rust keywords should parse correctly.
+/// CSS has properties like "align-self" where "self" is a keyword,
+/// and "float" which is also a keyword.
+#[wasm_bindgen_test]
+fn keyword_as_property_name() {
+	test_setup! {
+		float: "left";
+		text: "floating";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("float").unwrap(), "left");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod keyword_names;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Property parser used `Ident::parse()` which rejects Rust keywords
- Changed to `Ident::parse_any()` from `syn::ext::IdentExt` (already imported)
- CSS properties like `float`, `type`, and hyphenated ones containing keywords like `align-self` now parse correctly
- Also fixes the continuation segment parser for hyphenated property names

## Test plan
- [x] All 44 tests pass (`wasm-pack test --headless --chrome`)
- [x] New test: `float: "left"` property parses and applies correctly
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)