### PR TITLE
Add variable scoping test coverage

### DIFF
--- a/tests/data/variable_scope.rs
+++ b/tests/data/variable_scope.rs
@@ -1,0 +1,60 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// Variable defined at root should be accessible by child elements
+#[wasm_bindgen_test]
+fn parent_variable_accessible_by_child() {
+	test_setup! {
+		let $greeting: "hello";
+		child {
+			text: $greeting;
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.inner_html(), "hello");
+}
+
+/// Variable defined at root should be accessible by deeply nested elements
+#[wasm_bindgen_test]
+fn deeply_nested_variable_access() {
+	test_setup! {
+		let $msg: "deep";
+		outer {
+			inner {
+				text: $msg;
+			}
+		}
+	}
+	let outer = root.first_element_child().unwrap();
+	let inner = outer.first_element_child().unwrap();
+	assert_eq!(inner.inner_html(), "deep");
+}
+
+/// Mutable variable update should propagate through nested elements
+#[wasm_bindgen_test]
+fn mutable_variable_updates_nested_child() {
+	test_setup! {
+		let $status: "waiting";
+		display {
+			text: $status;
+		}
+		button {
+			text: "click";
+			?click {
+				$status: "clicked";
+			}
+		}
+	}
+	let display = root.children().item(0).unwrap();
+	let button = root.children().item(1).unwrap().dyn_into::<HtmlElement>().unwrap();
+	assert_eq!(display.inner_html(), "waiting");
+	button.click();
+	let display = root.children().item(0).unwrap();
+	assert_eq!(display.inner_html(), "clicked");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,6 +11,7 @@ mod data {
 	mod apply;
 	mod dynamic;
 	mod r#static;
+	mod variable_scope;
 }
 mod misc {
 	mod basics;


### PR DESCRIPTION
## Summary
- Adds 3 tests for variable scoping behavior
- `parent_variable_accessible_by_child`: static variable flows from root to child
- `deeply_nested_variable_access`: static variable flows through multiple nesting levels
- `mutable_variable_updates_nested_child`: mutable variable update propagates to child elements

## Test plan
- [x] All 46 tests pass (`wasm-pack test --headless --chrome`)
- [x] No compiler changes needed (coverage tests for existing functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)