### PR TITLE
Replace panic in register.rs with proper Page property handling

### DIFF
--- a/src/transform/compile/wasm/initialize/register.rs
+++ b/src/transform/compile/wasm/initialize/register.rs
@@ -63,7 +63,10 @@ impl Semantics {
 				Property::Cui(property) => quote! {
 					group.properties.insert(Property::#property, Value::String(#value));
 				},
-				_ => panic!("aaaAA"),
+				Property::Page(_) => {
+				// Page properties (e.g., title) should not appear in group registrations
+				quote! {}
+			}
 			});
 		quote! {
 			#( #elements )*


### PR DESCRIPTION
## Summary
- Replaced `panic!("aaaAA")` in `register.rs` with a proper match arm for `Property::Page(_)`
- Page properties (e.g., title) should never appear in runtime group registrations — they're handled at build time
- Now emits an empty token stream instead of crashing

## Test plan
- [x] All 43 tests pass (`wasm-pack test --headless --chrome`)
- [x] No behavioral change for valid code

🤖 Generated with [Claude Code](https://claude.com/claude-code)