### PR TITLE
Add tests for compiler default behaviors

### DIFF
--- a/tests/misc/defaults.rs
+++ b/tests/misc/defaults.rs
@@ -1,0 +1,54 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// Body should have margin: 0 as a default CSS reset
+#[wasm_bindgen_test]
+fn body_margin_zero() {
+	test_setup! {
+		text: "test";
+	}
+	let style = window.get_computed_style(&body).unwrap().unwrap();
+	assert_eq!(style.get_property_value("margin").unwrap(), "0px");
+}
+
+/// Link elements (<a> tags) should have display: block by default
+#[wasm_bindgen_test]
+fn link_display_block() {
+	test_setup! {
+		child {
+			link: "https://example.com";
+			text: "click";
+		}
+	}
+	let child = root.first_element_child().unwrap().dyn_into::<HtmlElement>().unwrap();
+	assert_eq!(child.tag_name(), "A");
+	let style = window.get_computed_style(&child).unwrap().unwrap();
+	assert_eq!(style.get_property_value("display").unwrap(), "block");
+}
+
+/// Elements should render as div tags by default
+#[wasm_bindgen_test]
+fn default_tag_is_div() {
+	test_setup! {
+		child {
+			text: "hello";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	assert_eq!(child.tag_name(), "DIV");
+}
+
+/// Root element should be a div by default
+#[wasm_bindgen_test]
+fn root_is_div() {
+	test_setup! {
+		text: "root";
+	}
+	assert_eq!(root.tag_name(), "DIV");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,7 @@ mod data {
 mod misc {
 	mod basics;
 	mod complex;
+	mod defaults;
 	mod events;
 }
 mod properties {


### PR DESCRIPTION
## Summary
- Documents and tests 4 default compiler behaviors that had no explicit tests
- `body_margin_zero`: verifies the body CSS reset (margin: 0)
- `link_display_block`: verifies `<a>` tags get display: block by default
- `default_tag_is_div`: verifies elements render as `<div>` tags
- `root_is_div`: verifies the root element is a `<div>`

## Test plan
- [x] All 47 tests pass (`wasm-pack test --headless --chrome`)
- [x] No compiler changes needed (coverage tests for existing defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)