### PR TITLE
Add negative number value test coverage

### DIFF
--- a/tests/properties/negative_values.rs
+++ b/tests/properties/negative_values.rs
@@ -1,0 +1,38 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn negative_z_index() {
+	test_setup! {
+		z-index: -1;
+		position: "relative";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("z-index").unwrap(), "-1");
+}
+
+#[wasm_bindgen_test]
+fn negative_margin() {
+	test_setup! {
+		margin-top: "-10px";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("margin-top").unwrap(), "-10px");
+}
+
+#[wasm_bindgen_test]
+fn negative_number_in_variable() {
+	test_setup! {
+		let $offset: -5;
+		z-index: $offset;
+		position: "relative";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("z-index").unwrap(), "-5");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod negative_values;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Adds 3 tests verifying negative numeric values work in CSS properties
- Tests cover `z-index: -1`, negative margins via string, and negative numbers in variable declarations
- Pure test coverage — no compiler changes needed

## Test plan
- [x] `negative_z_index` — verifies `z-index: -1` produces correct computed style
- [x] `negative_margin` — verifies negative string value for margin-top
- [x] `negative_number_in_variable` — verifies negative numbers work in `let $var: -5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)