### PR TITLE
Replace panic with compile_error for undeclared variable references

### DIFF
--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -17,8 +17,8 @@ pub struct Page {
 
 #[derive(Default)]
 pub struct Semantics {
-	pub errors: Vec<&'static str>,
-	pub warnings: Vec<&'static str>,
+	pub errors: Vec<String>,
+	pub warnings: Vec<String>,
 	pub styles: CssRules,
 
 	pub pages: Vec<Page>,

--- a/src/transform/render/value.rs
+++ b/src/transform/render/value.rs
@@ -72,7 +72,12 @@ impl Semantics {
 						);
 					}
 				}
-				panic!("unable to render variable '{}' from ancestors", identifier)
+				self.errors.push(format!(
+					"variable '{}' is not declared. Add `let ${}: \"default_value\";` in an ancestor scope.",
+					identifier, identifier
+				));
+				// Return a placeholder value so compilation can continue and report the error
+				Value::Static(StaticValue::String(String::new()))
 			}
 			Value::Variable(..) => value, // already rendered, idempotent
 			value => value,


### PR DESCRIPTION
## Summary
- Changed `errors`/`warnings` in Semantics from `Vec<&'static str>` to `Vec<String>` to support dynamic error messages
- When a variable like `$text` is referenced but never declared with `let`, the compiler now emits a helpful `compile_error!` instead of panicking the proc macro
- Error message: `variable 'text' is not declared. Add 'let $text: "default_value";' in an ancestor scope.`

## Test plan
- [x] All 43 existing tests pass
- [x] Previously, using an undeclared variable caused `panic!("unable to render variable '{}' from ancestors")` — now it produces a readable compiler error

🤖 Generated with [Claude Code](https://claude.com/claude-code)