### PR TITLE
Add 13 new events and addEventListener fallback for custom events

### DIFF
--- a/src/transform/compile/wasm/initialize/compiled.rs
+++ b/src/transform/compile/wasm/initialize/compiled.rs
@@ -90,23 +90,37 @@ impl Semantics {
 					return quote! {};
 				}
 
-				let event = match &**self.groups[listener_id]
+				let name = &**self.groups[listener_id]
 					.name
 					.as_ref()
-					.expect("every listener should have an event id")
-				{
-					"blur" => quote! { set_onblur },
-					"focus" => quote! { set_onfocus },
-					"click" => quote! { set_onclick },
-					"mouseover" => quote! { set_onmouseover },
-					"mouseenter" => quote! { set_onmouseenter },
-					"mouseleave" => quote! { set_onmouseleave },
-					"mouseout" => quote! { set_onmouseout },
-					_ => panic!("unknown event id"),
+					.expect("every listener should have an event id");
+
+				let setter = match name {
+					"blur" => Some(quote! { set_onblur }),
+					"focus" => Some(quote! { set_onfocus }),
+					"click" => Some(quote! { set_onclick }),
+					"dblclick" => Some(quote! { set_ondblclick }),
+					"mousedown" => Some(quote! { set_onmousedown }),
+					"mouseup" => Some(quote! { set_onmouseup }),
+					"mousemove" => Some(quote! { set_onmousemove }),
+					"mouseover" => Some(quote! { set_onmouseover }),
+					"mouseenter" => Some(quote! { set_onmouseenter }),
+					"mouseleave" => Some(quote! { set_onmouseleave }),
+					"mouseout" => Some(quote! { set_onmouseout }),
+					"keydown" => Some(quote! { set_onkeydown }),
+					"keyup" => Some(quote! { set_onkeyup }),
+					"keypress" => Some(quote! { set_onkeypress }),
+					"input" => Some(quote! { set_oninput }),
+					"change" => Some(quote! { set_onchange }),
+					"submit" => Some(quote! { set_onsubmit }),
+					"scroll" => Some(quote! { set_onscroll }),
+					"contextmenu" => Some(quote! { set_oncontextmenu }),
+					"wheel" => Some(quote! { set_onwheel }),
+					_ => None,
 				};
 
 				let rules = self.provide_state(rules);
-				quote! {
+				let closure = quote! {
 					let closure = {
 						let document = document.clone();
 						let mut element = element.clone();
@@ -118,8 +132,24 @@ impl Semantics {
 							});
 						}) as Box<dyn FnMut(Event)>)
 					};
-					element.#event(Some(closure.as_ref().unchecked_ref()));
-					closure.forget();
+				};
+
+				if let Some(event) = setter {
+					quote! {
+						#closure
+						element.#event(Some(closure.as_ref().unchecked_ref()));
+						closure.forget();
+					}
+				} else {
+					let event_name = name;
+					quote! {
+						#closure
+						element.add_event_listener_with_callback(
+							#event_name,
+							closure.as_ref().unchecked_ref(),
+						).unwrap();
+						closure.forget();
+					}
 				}
 			})
 			.collect()

--- a/tests/misc/expanded_events.rs
+++ b/tests/misc/expanded_events.rs
@@ -1,0 +1,65 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn dblclick_event() {
+	test_setup! {
+		text: "double click me";
+		?dblclick {
+			text: "double clicked!";
+		}
+	}
+	assert_eq!(root.inner_html(), "double click me");
+	// Simulate dblclick via web_sys
+	let event = web_sys::Event::new("dblclick").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "double clicked!");
+}
+
+#[wasm_bindgen_test]
+fn mousedown_event() {
+	test_setup! {
+		text: "press me";
+		?mousedown {
+			text: "pressed!";
+		}
+	}
+	assert_eq!(root.inner_html(), "press me");
+	let event = web_sys::Event::new("mousedown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "pressed!");
+}
+
+#[wasm_bindgen_test]
+fn keydown_event() {
+	test_setup! {
+		text: "type here";
+		?keydown {
+			text: "key pressed!";
+		}
+	}
+	assert_eq!(root.inner_html(), "type here");
+	let event = web_sys::Event::new("keydown").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "key pressed!");
+}
+
+#[wasm_bindgen_test]
+fn custom_event_via_add_event_listener() {
+	test_setup! {
+		text: "waiting";
+		?customevent {
+			text: "custom triggered!";
+		}
+	}
+	assert_eq!(root.inner_html(), "waiting");
+	let event = web_sys::Event::new("customevent").unwrap();
+	root.dispatch_event(&event).unwrap();
+	assert_eq!(root.inner_html(), "custom triggered!");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod expanded_events;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Expanded event listener support from 7 hardcoded events to 20 named events
- Added `addEventListener` fallback so ANY event name works (e.g., `?customevent {}`)
- Replaced `panic!("unknown event id")` with graceful handling
- New events: dblclick, mousedown, mouseup, mousemove, keydown, keyup, keypress, input, change, submit, scroll, contextmenu, wheel

## Test plan
- [x] `dblclick_event` — double-click handler fires correctly
- [x] `mousedown_event` — mousedown handler fires correctly
- [x] `keydown_event` — keydown handler fires correctly
- [x] `custom_event_via_add_event_listener` — arbitrary event name works via addEventListener
- [x] All 43 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)