### PR TITLE
Fix atomic ordering race condition in id_gen counters

### DIFF
--- a/src/misc/id_gen.rs
+++ b/src/misc/id_gen.rs
@@ -11,8 +11,7 @@ static SYMBOLS_2: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 
 
 pub fn generate_class_id() -> String {
 	let mut id = String::from("");
-	let mut n = CLASS_COUNTER.load(Ordering::Relaxed);
-	CLASS_COUNTER.swap(n + 1, Ordering::Relaxed);
+	let mut n = CLASS_COUNTER.fetch_add(1, Ordering::SeqCst);
 
 	loop {
 		let symbol_pool = if id.is_empty() {
@@ -35,11 +34,9 @@ pub fn generate_class_id() -> String {
 }
 
 pub fn generate_mutable_id() -> usize {
-	let n = MUTABLE_COUNTER.load(Ordering::Relaxed);
-	MUTABLE_COUNTER.swap(n + 1, Ordering::Relaxed);
-	n
+	MUTABLE_COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
 pub fn reset_mutable_counter() {
-	MUTABLE_COUNTER.swap(0, Ordering::Relaxed);
+	MUTABLE_COUNTER.store(0, Ordering::SeqCst);
 }


### PR DESCRIPTION
## Summary
- Replace `load` + `swap` pattern with `fetch_add(1, SeqCst)` for both `CLASS_COUNTER` and `MUTABLE_COUNTER`
- The previous pattern had a TOCTOU race: two threads could `load` the same value before either `swap`s, producing duplicate IDs
- Use `store` instead of `swap` for `reset_mutable_counter` since the old value is unused

## Test plan
- [x] All 43 existing tests pass
- [x] No behavioral change in single-threaded use — this prevents a latent concurrency bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)