### PR TITLE
Implement tooltip: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,12 +58,19 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let tooltip = self.properties.get(&Property::Cui(CuiProperty::Tooltip));
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",
 				&*link
+					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
+					.to_string(),
+			),
+			(
+				"title",
+				&*tooltip
 					.unwrap_or(&Value::Static(StaticValue::String("".to_string())))
 					.to_string(),
 			),

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,15 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Tooltip)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value {
+					element.set_title(s);
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -119,7 +119,11 @@ impl Semantics {
 					Property::Css(property) => element.css(property, value),
 					Property::Link => (),
 					Property::Text => element.text(value),
-					Property::Tooltip => (),
+					Property::Tooltip => {
+						if let Value::String(s) = value {
+							element.set_title(s);
+						}
+					}
 					Property::Image => (),
 					Property::Apply => (),
 				}

--- a/tests/properties/tooltip.rs
+++ b/tests/properties/tooltip.rs
@@ -1,0 +1,43 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn tooltip_sets_title_attribute() {
+	test_setup! {
+		text: "hover me";
+		tooltip: "This is a tooltip";
+	}
+	assert_eq!(root.get_attribute("title").unwrap(), "This is a tooltip");
+}
+
+#[wasm_bindgen_test]
+fn tooltip_on_child_element() {
+	test_setup! {
+		child {
+			text: "hover me";
+			tooltip: "Child tooltip";
+		}
+	}
+	let child = root.first_element_child().expect("should have child");
+	assert_eq!(child.get_attribute("title").unwrap(), "Child tooltip");
+}
+
+#[wasm_bindgen_test]
+fn tooltip_from_class() {
+	test_setup! {
+		.tip {
+			tooltip: "Class tooltip";
+		}
+		tip {
+			text: "hover me";
+		}
+	}
+	let element = root.first_element_child().expect("should have element");
+	assert_eq!(element.get_attribute("title").unwrap(), "Class tooltip");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,4 +20,5 @@ mod misc {
 mod properties {
 	mod text;
 	mod title;
+	mod tooltip;
 }


### PR DESCRIPTION
## Summary
- Implemented codegen for the `tooltip:` CUI property which was previously parsed but had no effect
- Tooltip maps to the HTML `title` attribute (browser-native tooltip on hover)
- Three codegen paths implemented:
  - **Static HTML** (html.rs): adds `title` attribute to rendered elements
  - **Runtime render** (render.rs): calls `element.set_title(s)`
  - **Dynamic compiled** (dynamic.rs): handles tooltip updates in listener contexts

## Test plan
- [x] `tooltip_sets_title_attribute` — tooltip on root element produces `title` attribute
- [x] `tooltip_on_child_element` — tooltip on nested element works
- [x] `tooltip_from_class` — tooltip cascaded from class to matching element
- [x] All 43 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)