### PR TITLE
Implement image: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,8 +58,15 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let mut inline_style = self.properties.css();
+		if let Some(image_value) = self.properties.get(&Property::Cui(CuiProperty::Image)) {
+			let url = image_value.to_string();
+			if !url.is_empty() {
+				inline_style.push_str(&format!("background-image:url({});background-size:cover;", url));
+			}
+		}
 		let attributes = [
-			("style", &*self.properties.css()),
+			("style", &*inline_style),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,16 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+	if let Some(value) = properties.get(&Property::Cui(CuiProperty::Image)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(url) = #value {
+					element.style().set_property("background-image", &format!("url({})", url)).unwrap();
+					element.style().set_property("background-size", "cover").unwrap();
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -120,7 +120,12 @@ impl Semantics {
 					Property::Link => (),
 					Property::Text => element.text(value),
 					Property::Tooltip => (),
-					Property::Image => (),
+					Property::Image => {
+						if let Value::String(url) = value {
+							element.style().set_property("background-image", &format!("url({})", url)).unwrap();
+							element.style().set_property("background-size", "cover").unwrap();
+						}
+					}
 					Property::Apply => (),
 				}
 			}

--- a/tests/properties/image.rs
+++ b/tests/properties/image.rs
@@ -1,0 +1,39 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn image_sets_background_image_style() {
+	test_setup! {
+		image: "https://example.com/photo.png";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	let bg = style.get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("example.com/photo.png"),
+		"background-image should contain the URL, got: {}",
+		bg
+	);
+}
+
+#[wasm_bindgen_test]
+fn image_on_child_element() {
+	test_setup! {
+		child {
+			image: "https://example.com/child.jpg";
+		}
+	}
+	let child = root.first_element_child().expect("should have child");
+	let style = window.get_computed_style(&child).unwrap().unwrap();
+	let bg = style.get_property_value("background-image").unwrap();
+	assert!(
+		bg.contains("example.com/child.jpg"),
+		"background-image should contain the URL, got: {}",
+		bg
+	);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod image;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Implemented codegen for the `image:` CUI property which was previously parsed but had no effect
- Image maps to `background-image: url(...)` and `background-size: cover` CSS styles
- Three codegen paths implemented:
  - **Static HTML** (html.rs): adds inline background-image style
  - **Runtime render** (render.rs): sets background-image and background-size via style API
  - **Dynamic compiled** (dynamic.rs): handles image updates in listener contexts

## Test plan
- [x] `image_sets_background_image_style` — image URL produces correct background-image
- [x] `image_on_child_element` — image on nested element works
- [x] All 43 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)