### PR TITLE
Fix Rust keyword parsing in CSS property names

### DIFF
--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -86,10 +86,11 @@ impl Parse for Block {
 impl Parse for Property {
 	fn parse(input: ParseStream) -> Result<Self, syn::Error> {
 		// Parse hyphenated property names like font-family, max-width, etc.
-		let mut property = input.parse::<Ident>()?.to_string();
+		// Use parse_any to accept Rust keywords (e.g., type, box) as property names.
+		let mut property = Ident::parse_any(input)?.to_string();
 		while input.peek(Token![-]) {
 			input.parse::<Token![-]>()?;
-			let next = input.parse::<Ident>()?;
+			let next = Ident::parse_any(input)?;
 			property.push('-');
 			property.push_str(&next.to_string());
 		}

--- a/tests/properties/keyword_names.rs
+++ b/tests/properties/keyword_names.rs
@@ -1,0 +1,19 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+// CSS properties containing Rust keywords should parse correctly
+#[wasm_bindgen_test]
+fn align_self_property() {
+	test_setup! {
+		display: "flex";
+		align-self: "center";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("align-self").unwrap(), "center");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod keyword_names;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Use `Ident::parse_any` instead of `Ident::parse` for property name tokens
- Fixes CSS properties containing Rust keywords: `align-self`, `justify-self`, `box-sizing`, etc.
- Both the initial identifier and hyphenated segments now accept keywords

## Test plan
- [x] `align_self_property` — `align-self: "center"` parses and applies correctly
- [x] All 43 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)