### PR TITLE
Enable classes_1 disabled test — already passes

### DIFF
--- a/tests/data/dynamic.rs
+++ b/tests/data/dynamic.rs
@@ -54,32 +54,38 @@ fn between_listeners() {
 	assert_eq!(root.inner_html(), "hello world<div></div>");
 }
 
-// TODO: classes_1, classes_2, classes_3 require class+mutable variable interaction
-// which needs EffectTarget::Class handling. See SUGGESTIONS.md.
+// TODO: classes_2 has invalid syntax (bare `?` listener, empty `$text: ;`).
+// TODO: classes_3 uses `$text` without a `let` declaration.
 
-// #[wasm_bindgen_test]
-// fn classes_1() {
-// 	test_setup! {
-// 		text: $text;
-// 		let $text: "hello world";
-// 		?click {
-// 			$text: "1";
-// 		}
-//
-// 		a {
-// 			text: $text;
-// 		}
-// 		b {
-// 			text: $text;
-// 			?click {
-// 				$text: "2";
-// 			}
-// 		}
-// 	}
-// 	// After fixing EffectTarget::Class, assertions should verify:
-// 	// - All elements referencing $text update when it changes
-// 	// - Priority: b's click handler sets $text: "2" which propagates to all references
-// }
+#[wasm_bindgen_test]
+fn classes_1() {
+	test_setup! {
+		text: $text;
+		let $text: "hello world";
+		?click {
+			$text: "1";
+		}
+
+		a {
+			text: $text;
+		}
+		b {
+			text: $text;
+			?click {
+				$text: "2";
+			}
+		}
+	}
+	// Root and two child elements all read $text
+	assert_eq!(root.inner_html(), "hello world<div>hello world</div><div>hello world</div>");
+	// Clicking root sets $text to "1" — all readers update
+	root.click();
+	assert_eq!(root.inner_html(), "1<div>1</div><div>1</div>");
+	// Clicking the second child (b) sets $text to "2" — all readers update
+	let b_element = root.children().item(1).unwrap().dyn_into::<HtmlElement>().unwrap();
+	b_element.click();
+	assert_eq!(root.inner_html(), "2<div>2</div><div>2</div>");
+}
 
 // #[wasm_bindgen_test]
 // fn classes_2() {


### PR DESCRIPTION
## Summary
- Enables the `classes_1` test that was disabled with a TODO about `EffectTarget::Class`
- The test actually passes — multiple elements reading the same mutable variable all update correctly when it changes
- Adds proper assertions: root click sets `$text: "1"`, child click sets `$text: "2"`, all three readers update
- Updates TODO comments for `classes_2` and `classes_3` with their actual root causes (invalid syntax and undeclared variable)

## Test plan
- [x] `classes_1` test passes with full assertions
- [x] All 44 tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)