### PR TITLE
Replace panics with compile errors for properties and variables

### DIFF
--- a/src/data/semantics/mod.rs
+++ b/src/data/semantics/mod.rs
@@ -17,8 +17,8 @@ pub struct Page {
 
 #[derive(Default)]
 pub struct Semantics {
-	pub errors: Vec<&'static str>,
-	pub warnings: Vec<&'static str>,
+	pub errors: Vec<String>,
+	pub warnings: Vec<String>,
 	pub styles: CssRules,
 
 	pub pages: Vec<Page>,

--- a/src/data/semantics/properties/mod.rs
+++ b/src/data/semantics/properties/mod.rs
@@ -29,22 +29,21 @@ fn is_css_property(name: &str) -> bool {
 }
 
 impl Property {
-	pub fn new(property: String) -> Self {
+	pub fn new(property: String) -> Result<Self, String> {
 		if is_css_property(&property) {
-			Self::Css(property)
+			Ok(Self::Css(property))
 		} else {
 			match property.as_str() {
-				"title" => Self::Page(PageProperty::Title),
-
-				property => Self::Cui(match property {
-					"text" => CuiProperty::Text,
-					"link" => CuiProperty::Link,
-					"tooltip" => CuiProperty::Tooltip,
-					"image" => CuiProperty::Image,
-					"apply" => CuiProperty::Apply,
-
-					property => panic!(" property not recognized: {}", property),
-				}),
+				"title" => Ok(Self::Page(PageProperty::Title)),
+				"text" => Ok(Self::Cui(CuiProperty::Text)),
+				"link" => Ok(Self::Cui(CuiProperty::Link)),
+				"tooltip" => Ok(Self::Cui(CuiProperty::Tooltip)),
+				"image" => Ok(Self::Cui(CuiProperty::Image)),
+				"apply" => Ok(Self::Cui(CuiProperty::Apply)),
+				property => Err(format!(
+					"property '{}' is not recognized as a CSS or CUI property",
+					property
+				)),
 			}
 		}
 	}

--- a/src/transform/analyze.rs
+++ b/src/transform/analyze.rs
@@ -108,11 +108,17 @@ impl Semantics {
 				group_id
 			);
 			let value = self.create_semantic_value(&value);
-			let property = Property::new(property);
-			if let Property::Css(_) = property {
-				self.groups[group_id].has_css_properties = true;
+			match Property::new(property) {
+				Ok(property) => {
+					if let Property::Css(_) = property {
+						self.groups[group_id].has_css_properties = true;
+					}
+					self.groups[group_id].properties.insert(property, value);
+				}
+				Err(error) => {
+					self.errors.push(error);
+				}
 			}
-			self.groups[group_id].properties.insert(property, value);
 		}
 
 		for block in block.listeners {

--- a/src/transform/compile/wasm/initialize/register.rs
+++ b/src/transform/compile/wasm/initialize/register.rs
@@ -63,7 +63,11 @@ impl Semantics {
 				Property::Cui(property) => quote! {
 					group.properties.insert(Property::#property, Value::String(#value));
 				},
-				_ => panic!("aaaAA"),
+				Property::Page(_) => {
+					// Page properties (title) are handled at the document level,
+					// not at the group registration level
+					quote! {}
+				}
 			});
 		quote! {
 			#( #elements )*

--- a/src/transform/render/value.rs
+++ b/src/transform/render/value.rs
@@ -72,7 +72,12 @@ impl Semantics {
 						);
 					}
 				}
-				panic!("unable to render variable '{}' from ancestors", identifier)
+				self.errors.push(format!(
+						"variable '{}' is not declared in any ancestor scope. Add 'let ${}: \"value\";' to declare it.",
+						identifier, identifier
+					));
+					// Return a placeholder value so compilation can continue and report the error
+					Value::Static(StaticValue::String(String::new()))
 			}
 			Value::Variable(..) => value, // already rendered, idempotent
 			value => value,

--- a/tests/misc/error_handling.rs
+++ b/tests/misc/error_handling.rs
@@ -1,0 +1,21 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+/// Verify that valid properties work alongside each other
+#[wasm_bindgen_test]
+fn multiple_valid_properties() {
+	test_setup! {
+		text: "hello";
+		color: "red";
+		display: "block";
+	}
+	assert_eq!(root.inner_html(), "hello");
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,7 @@ mod data {
 mod misc {
 	mod basics;
 	mod complex;
+	mod error_handling;
 	mod events;
 }
 mod properties {


### PR DESCRIPTION
## Summary
- `Property::new` returns `Result<Self, String>` instead of panicking on unknown properties — errors become `compile_error!` messages
- `register.rs`: replaces `panic!("aaaAA")` with proper `Property::Page(_)` match arm (Page properties handled at document level)
- `value.rs`: replaces `panic!("unable to render variable")` with descriptive compile error and placeholder value
- Changes `errors`/`warnings` vecs from `&'static str` to `String` for dynamic error messages

## Test plan
- [x] `multiple_valid_properties` — verifies valid properties still work correctly
- [x] All 44 existing tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)