### PR TITLE
Fix atomic counter race condition with fetch_add

### DIFF
--- a/src/misc/id_gen.rs
+++ b/src/misc/id_gen.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 
 static CLASS_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static MUTABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -11,8 +11,7 @@ static SYMBOLS_2: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 
 
 pub fn generate_class_id() -> String {
 	let mut id = String::from("");
-	let mut n = CLASS_COUNTER.load(Ordering::Relaxed);
-	CLASS_COUNTER.swap(n + 1, Ordering::Relaxed);
+	let mut n = CLASS_COUNTER.fetch_add(1, SeqCst);
 
 	loop {
 		let symbol_pool = if id.is_empty() {
@@ -35,11 +34,9 @@ pub fn generate_class_id() -> String {
 }
 
 pub fn generate_mutable_id() -> usize {
-	let n = MUTABLE_COUNTER.load(Ordering::Relaxed);
-	MUTABLE_COUNTER.swap(n + 1, Ordering::Relaxed);
-	n
+	MUTABLE_COUNTER.fetch_add(1, SeqCst)
 }
 
 pub fn reset_mutable_counter() {
-	MUTABLE_COUNTER.swap(0, Ordering::Relaxed);
+	MUTABLE_COUNTER.store(0, SeqCst);
 }


### PR DESCRIPTION
## Summary
- Replaces `load + swap` pattern with `fetch_add(1, SeqCst)` for both `CLASS_COUNTER` and `MUTABLE_COUNTER`
- The old pattern had a TOCTOU race: two concurrent macro invocations could read the same counter value
- Uses `store()` instead of `swap()` for `reset_mutable_counter` since the old value is unused
- Changes ordering from `Relaxed` to `SeqCst` for correctness

## Test plan
- [x] All 43 tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)