### PR TITLE
Accept Rust keywords as property names in parser

### DIFF
--- a/src/transform/parse/mod.rs
+++ b/src/transform/parse/mod.rs
@@ -86,10 +86,11 @@ impl Parse for Block {
 impl Parse for Property {
 	fn parse(input: ParseStream) -> Result<Self, syn::Error> {
 		// Parse hyphenated property names like font-family, max-width, etc.
-		let mut property = input.parse::<Ident>()?.to_string();
+		// Use parse_any to accept Rust keywords as property names (e.g. `type`)
+		let mut property = Ident::parse_any(input)?.to_string();
 		while input.peek(Token![-]) {
 			input.parse::<Token![-]>()?;
-			let next = input.parse::<Ident>()?;
+			let next = Ident::parse_any(input)?;
 			property.push('-');
 			property.push_str(&next.to_string());
 		}

--- a/tests/properties/keyword_names.rs
+++ b/tests/properties/keyword_names.rs
@@ -1,0 +1,18 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn type_as_property_name() {
+	test_setup! {
+		text: "hello";
+		box-sizing: "border-box";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("box-sizing").unwrap(), "border-box");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod keyword_names;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Changes property name parsing to use `Ident::parse_any` instead of `parse::<Ident>()`
- Both the initial identifier and hyphenated segments now accept Rust keywords (e.g., `type`, `box`)
- Needed for CSS properties that contain keyword-like segments

## Test plan
- [x] `type_as_property_name` — verifies `box-sizing` (contains keyword-like segment) works
- [x] All 44 tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)