### PR TITLE
Implement tooltip: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,9 +58,15 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let tooltip_value = self
+			.properties
+			.get(&Property::Cui(CuiProperty::Tooltip))
+			.map(|v| v.to_string())
+			.unwrap_or_default();
 		let attributes = [
 			("style", &*self.properties.css()),
 			("class", &*self.class_names.join(" ")),
+			("title", &*tooltip_value),
 			(
 				"href",
 				&*link

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,15 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Tooltip)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(s) = #value {
+					element.set_title(s);
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -119,7 +119,11 @@ impl Semantics {
 					Property::Css(property) => element.css(property, value),
 					Property::Link => (),
 					Property::Text => element.text(value),
-					Property::Tooltip => (),
+					Property::Tooltip => {
+						if let Value::String(s) = value {
+							element.set_title(s);
+						}
+					}
 					Property::Image => (),
 					Property::Apply => (),
 				}

--- a/tests/properties/tooltip.rs
+++ b/tests/properties/tooltip.rs
@@ -1,0 +1,45 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn tooltip_on_element() {
+	test_setup! {
+		text: "hover me";
+		tooltip: "This is a tooltip";
+	}
+	assert_eq!(root.title(), "This is a tooltip");
+}
+
+#[wasm_bindgen_test]
+fn tooltip_on_child() {
+	test_setup! {
+		item {
+			text: "child";
+			tooltip: "Child tooltip";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	let child: web_sys::HtmlElement = child.dyn_into().unwrap();
+	assert_eq!(child.title(), "Child tooltip");
+}
+
+#[wasm_bindgen_test]
+fn tooltip_from_class() {
+	test_setup! {
+		.tip {
+			tooltip: "Class tooltip";
+		}
+		tip {
+			text: "element";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	let child: web_sys::HtmlElement = child.dyn_into().unwrap();
+	assert_eq!(child.title(), "Class tooltip");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,4 +20,5 @@ mod misc {
 mod properties {
 	mod text;
 	mod title;
+	mod tooltip;
 }


### PR DESCRIPTION
## Summary
- Implements the `tooltip:` CUI property which was previously parsed but returned `()` in codegen
- Static HTML: renders as `title` attribute on elements
- Runtime: calls `element.set_title()` in `render_property`
- Compiled dynamic: handles tooltip values in `compiled_dynamic_properties`

## Test plan
- [x] `tooltip_on_element` — tooltip on root element
- [x] `tooltip_on_child` — tooltip on nested child
- [x] `tooltip_from_class` — tooltip cascades from class to element
- [x] All 46 tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)