### PR TITLE
Implement image: property codegen

### DIFF
--- a/src/transform/compile/html.rs
+++ b/src/transform/compile/html.rs
@@ -58,8 +58,18 @@ impl Semantics {
 impl Group {
 	fn html(&self, groups: &[Group]) -> String {
 		let link = self.properties.get(&Property::Cui(CuiProperty::Link));
+		let mut inline_style = self.properties.css();
+		if let Some(image_value) = self.properties.get(&Property::Cui(CuiProperty::Image)) {
+			let url = image_value.to_string();
+			if !url.is_empty() {
+				inline_style.push_str(&format!(
+					"background-image:url({});background-size:cover;",
+					url
+				));
+			}
+		}
 		let attributes = [
-			("style", &*self.properties.css()),
+			("style", &*inline_style),
 			("class", &*self.class_names.join(" ")),
 			(
 				"href",

--- a/src/transform/compile/wasm/initialize/dynamic.rs
+++ b/src/transform/compile/wasm/initialize/dynamic.rs
@@ -188,6 +188,16 @@ impl Semantics {
 			effects.push(quote! { element.text(#value); });
 		}
 
+		if let Some(value) = properties.get(&Property::Cui(CuiProperty::Image)) {
+			let value = self.compiled_dynamic_value(value);
+			effects.push(quote! {
+				if let Value::String(url) = #value {
+					element.style().set_property("background-image", &format!("url({})", url)).unwrap();
+					element.style().set_property("background-size", "cover").unwrap();
+				}
+			});
+		}
+
 		// if let Some(_value) = properties.get(&Property::Cui(CuiProperty::Link)) {
 		// 	effects.push(quote! {});
 		// }

--- a/src/transform/compile/wasm/runtime/render.rs
+++ b/src/transform/compile/wasm/runtime/render.rs
@@ -120,7 +120,12 @@ impl Semantics {
 					Property::Link => (),
 					Property::Text => element.text(value),
 					Property::Tooltip => (),
-					Property::Image => (),
+					Property::Image => {
+						if let Value::String(url) = value {
+							element.style().set_property("background-image", &format!("url({})", url)).unwrap();
+							element.style().set_property("background-size", "cover").unwrap();
+						}
+					}
 					Property::Apply => (),
 				}
 			}

--- a/tests/properties/image.rs
+++ b/tests/properties/image.rs
@@ -1,0 +1,32 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn image_sets_background() {
+	test_setup! {
+		image: "test.png";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	let bg = style.get_property_value("background-image").unwrap();
+	assert!(bg.contains("test.png"), "background-image should contain test.png, got: {}", bg);
+}
+
+#[wasm_bindgen_test]
+fn image_on_child() {
+	test_setup! {
+		banner {
+			image: "hero.jpg";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	let child: web_sys::HtmlElement = child.dyn_into().unwrap();
+	let style = window.get_computed_style(&child).unwrap().unwrap();
+	let bg = style.get_property_value("background-image").unwrap();
+	assert!(bg.contains("hero.jpg"), "background-image should contain hero.jpg, got: {}", bg);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod image;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Implements the `image:` CUI property which was previously parsed but returned `()` in codegen
- Renders as `background-image: url(...)` and `background-size: cover` inline styles
- Implemented in static HTML generation, runtime `render_property`, and `compiled_dynamic_properties`

## Test plan
- [x] `image_sets_background` — image on root element sets background-image
- [x] `image_on_child` — image on nested child element
- [x] All 45 tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)