### PR TITLE
Add 6 tests for multi-element classes and sibling ordering

### DIFF
--- a/tests/classes/multi_element.rs
+++ b/tests/classes/multi_element.rs
@@ -1,0 +1,57 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn class_applies_to_multiple_elements() {
+	test_setup! {
+		.styled {
+			color: "red";
+			text: "item";
+		}
+		styled {}
+		styled {}
+		styled {}
+	}
+	let children = root.children();
+	assert_eq!(children.length(), 3);
+	for i in 0..3 {
+		let child = children.item(i).unwrap();
+		assert_eq!(child.inner_html(), "item");
+	}
+}
+
+#[wasm_bindgen_test]
+fn different_classes_on_different_elements() {
+	test_setup! {
+		.a { text: "alpha"; }
+		.b { text: "beta"; }
+		a { }
+		b { }
+	}
+	let children = root.children();
+	assert_eq!(children.length(), 2);
+	assert_eq!(children.item(0).unwrap().inner_html(), "alpha");
+	assert_eq!(children.item(1).unwrap().inner_html(), "beta");
+}
+
+#[wasm_bindgen_test]
+fn class_with_nested_element() {
+	test_setup! {
+		.container {
+			text: "parent";
+			inner {
+				text: "child";
+			}
+		}
+		container {}
+	}
+	let container = root.first_element_child().unwrap();
+	assert!(container.inner_html().contains("parent"));
+	assert!(container.inner_html().contains("child"));
+}

--- a/tests/misc/sibling_order.rs
+++ b/tests/misc/sibling_order.rs
@@ -1,0 +1,49 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn siblings_maintain_order() {
+	test_setup! {
+		first { text: "1"; }
+		second { text: "2"; }
+		third { text: "3"; }
+	}
+	let children = root.children();
+	assert_eq!(children.length(), 3);
+	assert_eq!(children.item(0).unwrap().inner_html(), "1");
+	assert_eq!(children.item(1).unwrap().inner_html(), "2");
+	assert_eq!(children.item(2).unwrap().inner_html(), "3");
+}
+
+#[wasm_bindgen_test]
+fn deep_nesting_order() {
+	test_setup! {
+		a {
+			b {
+				c {
+					text: "deep";
+				}
+			}
+		}
+	}
+	let a = root.first_element_child().unwrap();
+	let b = a.first_element_child().unwrap();
+	let c = b.first_element_child().unwrap();
+	assert_eq!(c.inner_html(), "deep");
+}
+
+#[wasm_bindgen_test]
+fn mixed_text_and_elements() {
+	test_setup! {
+		text: "parent";
+		child { text: "child"; }
+	}
+	assert!(root.inner_html().starts_with("parent"));
+	assert!(root.inner_html().contains("child"));
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,6 +5,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 mod classes {
 	mod basics;
 	mod event_parallel_nesting;
+	mod multi_element;
 	mod parallel_nesting;
 }
 mod data {
@@ -16,6 +17,7 @@ mod misc {
 	mod basics;
 	mod complex;
 	mod events;
+	mod sibling_order;
 }
 mod properties {
 	mod text;


### PR DESCRIPTION
## Summary
- Adds `tests/classes/multi_element.rs` with 3 tests: class applies to multiple elements, different classes on different elements, class with nested element children
- Adds `tests/misc/sibling_order.rs` with 3 tests: siblings maintain declaration order, deep nesting traversal, mixed text and child elements

## Test plan
- [x] All 6 new tests pass
- [x] All 49 total tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)