### PR TITLE
Add 3 tests for variable scoping and multi-reader propagation

### DIFF
--- a/tests/data/multi_reader.rs
+++ b/tests/data/multi_reader.rs
@@ -1,0 +1,62 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn variable_read_by_multiple_children() {
+	test_setup! {
+		let $msg: "hello";
+		a { text: $msg; }
+		b { text: $msg; }
+		c { text: $msg; }
+	}
+	let children = root.children();
+	assert_eq!(children.length(), 3);
+	for i in 0..3 {
+		assert_eq!(children.item(i).unwrap().inner_html(), "hello");
+	}
+}
+
+#[wasm_bindgen_test]
+fn variable_updated_propagates_to_all_readers() {
+	test_setup! {
+		let $msg: "before";
+		?click {
+			$msg: "after";
+		}
+		a { text: $msg; }
+		b { text: $msg; }
+	}
+	let children = root.children();
+	assert_eq!(children.item(0).unwrap().inner_html(), "before");
+	assert_eq!(children.item(1).unwrap().inner_html(), "before");
+	root.click();
+	assert_eq!(children.item(0).unwrap().inner_html(), "after");
+	assert_eq!(children.item(1).unwrap().inner_html(), "after");
+}
+
+#[wasm_bindgen_test]
+fn variable_in_nested_scope() {
+	test_setup! {
+		let $color: "red";
+		outer {
+			color: $color;
+			text: "outer";
+			inner {
+				color: $color;
+				text: "inner";
+			}
+		}
+	}
+	let outer = root.first_element_child().unwrap();
+	let outer_style = window.get_computed_style(&outer).unwrap().unwrap();
+	assert_eq!(outer_style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+	let inner = outer.first_element_child().unwrap();
+	let inner_style = window.get_computed_style(&inner).unwrap().unwrap();
+	assert_eq!(inner_style.get_property_value("color").unwrap(), "rgb(255, 0, 0)");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ mod classes {
 mod data {
 	mod apply;
 	mod dynamic;
+	mod multi_reader;
 	mod r#static;
 }
 mod misc {


### PR DESCRIPTION
## Summary
- Adds `tests/data/multi_reader.rs` with 3 tests for variable scoping behavior:
  - `variable_read_by_multiple_children` — static variable shared across 3 child elements
  - `variable_updated_propagates_to_all_readers` — mutable variable click-update reaches all readers
  - `variable_in_nested_scope` — variable resolves correctly in nested element scopes with CSS property

## Test plan
- [x] All 3 new tests pass
- [x] All 46 total tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)