### PR TITLE
Add 3 tests for property overriding and CSS coexistence

### DIFF
--- a/tests/properties/override_tests.rs
+++ b/tests/properties/override_tests.rs
@@ -1,0 +1,44 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn later_property_overrides_earlier() {
+	test_setup! {
+		text: "first";
+		text: "second";
+	}
+	assert_eq!(root.inner_html(), "second");
+}
+
+#[wasm_bindgen_test]
+fn class_property_applied_to_element() {
+	test_setup! {
+		.styled {
+			color: "blue";
+		}
+		styled {
+			text: "colored";
+		}
+	}
+	let child = root.first_element_child().unwrap();
+	let style = window.get_computed_style(&child).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(0, 0, 255)");
+}
+
+#[wasm_bindgen_test]
+fn multiple_css_properties() {
+	test_setup! {
+		color: "green";
+		font-size: "20px";
+		text: "styled";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("color").unwrap(), "rgb(0, 128, 0)");
+	assert_eq!(style.get_property_value("font-size").unwrap(), "20px");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod override_tests;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- `later_property_overrides_earlier` — verifies last-wins semantics for duplicate properties
- `class_property_applied_to_element` — verifies class CSS cascades correctly to elements
- `multiple_css_properties` — verifies multiple CSS properties coexist on one element

## Test plan
- [x] All 3 new tests pass
- [x] All 46 total tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)