### PR TITLE
Add 3 tests for negative values and number properties

### DIFF
--- a/tests/properties/negative_values.rs
+++ b/tests/properties/negative_values.rs
@@ -1,0 +1,37 @@
+extern crate cascading_ui;
+extern crate wasm_bindgen_test;
+use self::{
+	cascading_ui::{test_header, test_setup},
+	wasm_bindgen_test::wasm_bindgen_test,
+};
+
+test_header!();
+
+#[wasm_bindgen_test]
+fn negative_z_index() {
+	test_setup! {
+		z-index: -1;
+		position: "relative";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("z-index").unwrap(), "-1");
+}
+
+#[wasm_bindgen_test]
+fn negative_margin() {
+	test_setup! {
+		margin-top: "-10px";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("margin-top").unwrap(), "-10px");
+}
+
+#[wasm_bindgen_test]
+fn positive_number() {
+	test_setup! {
+		z-index: 5;
+		position: "relative";
+	}
+	let style = window.get_computed_style(&root).unwrap().unwrap();
+	assert_eq!(style.get_property_value("z-index").unwrap(), "5");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod misc {
 	mod events;
 }
 mod properties {
+	mod negative_values;
 	mod text;
 	mod title;
 }


### PR DESCRIPTION
## Summary
- Adds tests verifying numeric property values work correctly
- `negative_z_index` — `z-index: -1` with numeric literal
- `negative_margin` — `margin-top: "-10px"` with string value
- `positive_number` — `z-index: 5` as positive numeric literal

## Test plan
- [x] All 3 new tests pass
- [x] All 46 total tests pass
- [x] `wasm-pack test --headless --chrome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)